### PR TITLE
ZeeTerminal v1.0.0 PR (FIRST PUBLIC RELEASE AYYYY)

### DIFF
--- a/CommandFiles/CPUStress.cpp
+++ b/CommandFiles/CPUStress.cpp
@@ -11,15 +11,32 @@ bool bCpuStressKeyboardTermination = false;
 
 extern ConfigFileSystem ConfigObjMain;
 
+#include <random>
+
 
 // Worker for CPU Stress Test
 void CpuStressTestWorker() {
 	long double ldStress = 1.0; 
 
 	while (!StopCpuStress) {
-		ldStress *= RandNumld(0, 5);
-		ldStress /= RandNumld(0.00000001, 5);
-		ldStress += RandNumld(0, 5);
+		// 15 rounds of random number generation
+		ldStress *= RandNumld(M_PI * 2, 0.000000001);
+		ldStress /= RandNumld(M_PI * 2, 0.000000001);
+		ldStress *= RandNumld(M_PI * 2, 0.000000001);
+		ldStress /= RandNumld(M_PI * 2, 0.000000001);
+		ldStress *= RandNumld(M_PI * 2, 0.000000001);
+
+		ldStress /= RandNumld(M_PI * 2, 0.000000001);
+		ldStress *= RandNumld(M_PI * 2, 0.000000001);
+		ldStress /= RandNumld(M_PI * 2, 0.000000001);
+		ldStress *= RandNumld(M_PI * 2, 0.000000001);
+		ldStress /= RandNumld(M_PI * 2, 0.000000001);
+
+		ldStress /= RandNumld(M_PI * 2, 0.000000001);
+		ldStress *= RandNumld(M_PI * 2, 0.000000001);
+		ldStress /= RandNumld(M_PI * 2, 0.000000001);
+		ldStress *= RandNumld(M_PI * 2, 0.000000001);
+		ldStress /= RandNumld(M_PI * 2, 0.000000001);
 	}
 
 	return;
@@ -30,11 +47,28 @@ void CpuBenchmarkWorker() {
 	long double ldStress = 1.0;
 
 	while (!StopCpuStress) {
-		ldStress *= RandNumld(0, 5);
-		ldStress /= RandNumld(0.00000001, 5);
-		ldStress += RandNumld(0, 5);
+		// 15 rounds of random number generation
+		ldStress *= RandNumld(M_PI * 2, 0.000000001);
+		ldStress /= RandNumld(M_PI * 2, 0.000000001);
+		ldStress *= RandNumld(M_PI * 2, 0.000000001);
+		ldStress /= RandNumld(M_PI * 2, 0.000000001);
+		ldStress *= RandNumld(M_PI * 2, 0.000000001);
+
+		ldStress /= RandNumld(M_PI * 2, 0.000000001);
+		ldStress *= RandNumld(M_PI * 2, 0.000000001);
+		ldStress /= RandNumld(M_PI * 2, 0.000000001);
+		ldStress *= RandNumld(M_PI * 2, 0.000000001);
+		ldStress /= RandNumld(M_PI * 2, 0.000000001);
+
+		ldStress /= RandNumld(M_PI * 2, 0.000000001);
+		ldStress *= RandNumld(M_PI * 2, 0.000000001);
+		ldStress /= RandNumld(M_PI * 2, 0.000000001);
+		ldStress *= RandNumld(M_PI * 2, 0.000000001);
+		ldStress /= RandNumld(M_PI * 2, 0.000000001);
+		
 		nCurrentReiterationNum++;
 	}
+
 	return;
 }
 

--- a/CommandFiles/CommandFileAssets.cpp
+++ b/CommandFiles/CommandFileAssets.cpp
@@ -260,7 +260,7 @@ void About(bool bFromTutorial) {
 	std::string sScreens[] =
 	{
 		"___ABOUT THIS PROGRAM___\n\nThis is the ZeeTerminal Commandline Program, Build v" + std::string(ZT_VERSION) + ".\n" +
-		"This is a beta build of ZeeTerminal, with an entirely new engine and components.\nThis program is made in C++, with a few very small parts of C." +
+		"This is a public stable release build of ZeeTerminal, with an entirely new engine and components.\nThis program is made in C++, with a few very small parts of C." +
 		"\n\nThis program uses the DirectShow API in the MediaPlayer command, licensed by Microsoft Corp. (c) Microsoft Corp.\n\n" +
 		"This program uses the BASS API in the AudioPlayer command, licensed by Un4Seen Developments. (c) Un4Seen Developments.\n\n" +
 		"This program uses the CarDodge game v0.6.0, accessible in the Game command. CarDodge is licensed under Ryan Zorkot with the MIT License. For more information, visit the archived repo: https://github.com/rforzachamp821/CarDodge\n\n"
@@ -537,7 +537,7 @@ void DevTools(short int nToolNum) {
 	// Colour Tester
 	if (nToolNum == 1) {
 		CentreColouredText(" ___COLOUR TESTER___ ", 1);
-		std::cout << "\n\n";
+		std::cout << wordWrap("\n\nNote that ANSI colour escape sequences may not be interpreted correctly or at all on older terminals, such as Windows 7.\n\n");
 
 		// Firstly, output all default colours
 		// Foreground
@@ -564,11 +564,17 @@ void DevTools(short int nToolNum) {
 		for (int i = 100; i <= 107; i++) {
 			std::cout << "\x1b[" << i << "mThis is background ANSI escape code colour <" << i << ">. 1234567890 (Light)\n";
 		}
-		// Reset background
-		std::cout << "\x1b[49m\n";
+		// Reset background to previous colours
+		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 
-		std::cout << "Press any key to exit...\n";
-		_getch();
+		std::cout << "Press ESC to exit...\n";
+		while (true) {
+			// _kbhit() to exit on ESC keypress
+			if (_kbhit()) {
+				if (_getch() == 27) break;
+			}
+			sleep(10);
+		}
 
 		return;
 	}
@@ -579,12 +585,12 @@ void DevTools(short int nToolNum) {
 
 		std::cout << '\n';
 		colourSubheading();
-		slowcharCentredFn(false, "This is a tester for the 'Beep' function in Windows.");
+		slowcharCentredFn(false, "This is a tester for the 'Beep()' function in Windows.");
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 		std::cout << NOULINE_STR << std::endl;
 		std::cout << wordWrap("ZeeTerminal will output a pitch of sound that increases by 100hz every second, until 22000hz.") << "\n\n";
 		colour(MAG, LYLW);
-		std::cout << wordWrap("You can press any key to exit in the middle of the test.");
+		std::cout << wordWrap("You can press ESC to exit in the middle of the test.");
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 		std::cout << wordWrap("\nPress any key to begin the test, or ESC to exit...\n");
 		char cKey = _getch();
@@ -596,11 +602,14 @@ void DevTools(short int nToolNum) {
 		for (int i = 100; i < 22000; i += 100) {
 			// clear line
 			std::cout << "\r                      \r";
-			// output
-			std::cout << "Outputting " << i << " hz...";
+			// output and colour the hertz value
+			std::cout << "Outputting ";
+			colour(LCYN, ConfigObjMain.sColourGlobalBack);
+			std::cout << i << " hz...";
+			colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 			Beep(i, 1000);
-			// stop if kbhit is true / keyboard key is pressed
-			if (_kbhit()) {
+			// stop if kbhit is true and ESC key was pressed
+			if (_kbhit() && _getch() == 27) {
 				colour(YLW, ConfigObjMain.sColourGlobalBack);
 				std::cout << "\nBeep Sound Test stopped.\n";
 				ClearKeyboardBuffer();
@@ -616,8 +625,21 @@ void DevTools(short int nToolNum) {
 	// ColourNumbers
 	else if (nToolNum == 3) {
 		// Execute the ColourNumbers command from the Command function
-		char cTemp[3] = { ' ', ' ', ' ' };
-		commands::Commands1To10("colournumbers", cTemp, "");
+		char cTemp[nArgArraySize];
+		for (int i = 0; i < nArgArraySize; i++) {
+			cTemp[i] = ' ';
+		}
+		commands::Commands11To20("colournumbers", cTemp, "");
+
+		std::cout << "\nPress ESC to exit...\n";
+		while (true) {
+			// _kbhit() to exit on ESC keypress
+			if (_kbhit()) {
+				if (_getch() == 27) break;
+			}
+			sleep(10);
+		}
+
 
 		return;
 	}
@@ -755,6 +777,7 @@ void DevTools(short int nToolNum) {
 
 	// TableEngine Tester
 	else if (nToolNum == 6) {
+		// Output title, headings
 		CentreColouredText(" ___TABLE-ENGINE TESTER___ ", 1);
 		std::cout << std::endl;
 		colourSubheading();
@@ -768,7 +791,7 @@ void DevTools(short int nToolNum) {
 			Exiting();
 			return;
 		}
-		uint64_t nNumOfColumns = PositiveNumInputull("\nPlease input now many columns you would like to create (0 to exit): > ");
+		uint64_t nNumOfColumns = PositiveNumInputull("\nPlease input how many columns you would like to create (0 to exit): > ");
 		if (nNumOfColumns <= 0) {
 			Exiting();
 			return;
@@ -808,8 +831,14 @@ void DevTools(short int nToolNum) {
 		// Finally, output table using TableEngine::OutputTable()
 		teTester.OutputTable();
 
-		std::cout << "\n\nPress ENTER to exit...\n";
-		std::cin.ignore(std::numeric_limits<int>::max(), '\n');
+		// Exit on ESC keypress
+		std::cout << "Press ESC to exit...\n";
+		while (true) {
+			if (_kbhit()) {
+				if (_getch() == 27) break;
+			}
+			sleep(10);
+		}
 
 		return;
 	}
@@ -826,7 +855,7 @@ void DevTools(short int nToolNum) {
 		// Prompt to start
 		std::cout << "\n\n";
 		colour(MAG, LYLW);
-		std::cout << wordWrap("You can press any key in the middle of the stopwatch run to stop it.");
+		std::cout << wordWrap("You can press the ESC key in the middle of the stopwatch run to stop it.");
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 		std::cout << wordWrap("\n\nPress any key to start the stopwatch, or ESC to exit...");
 		char cKey = _getch();
@@ -842,8 +871,13 @@ void DevTools(short int nToolNum) {
 		auto start = std::chrono::high_resolution_clock::now();
 		auto end = std::chrono::high_resolution_clock::now();
 
-		// _kbhit() to exit on keypress
-		while (!_kbhit()) {
+
+		while (true) {
+			// _kbhit() to exit on ESC keypress
+			if (_kbhit()) {
+				if (_getch() == 27) break;
+			}
+
 			end = std::chrono::high_resolution_clock::now();
 			std::cout << "Time: ";
 			colour(LCYN, ConfigObjMain.sColourGlobalBack);
@@ -876,7 +910,7 @@ void DevTools(short int nToolNum) {
 		slowcharCentredFn(false, "This is a sandbox-style testing enviroment for ANSI (VT) escape codes.");
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 
-		std::cout << NOULINE_STR << wordWrap("\n\nYou can test any ANSI escape code here. Everything will be reset after exiting the sandbox (by typing in 0 or \"zero\").");
+		std::cout << NOULINE_STR << wordWrap("\n\nYou can test any ANSI escape code here. Everything will be reset after exiting the sandbox (by typing in 0 or \"zero\").\nSome older terminals, e.g Windows 7 terminals, cannot interpret ANSI escape codes properly, therefore this may not produce intended results on those systems.");
 		colour(LBLU, ConfigObjMain.sColourGlobalBack);
 		std::cout << wordWrap("\nYou can get a list of ANSI VT escape codes here: https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences") << "\n\n";
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
@@ -906,7 +940,7 @@ void DevTools(short int nToolNum) {
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 		std::cout << NOULINE_STR << wordWrap("\n\nZeeTerminal will output a pitch of sound that starts at 20hz and increases by 100hz every second, until 22000hz.") << "\n\n";
 		colour(MAG, LYLW);
-		std::cout << wordWrap("You can press any key to exit in the middle of the test.");
+		std::cout << wordWrap("You can press ESC to exit in the middle of the test.");
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 		std::cout << wordWrap("\nPress any key to begin the test, or ESC to exit now...") << '\n';
 		char cKey = _getch();
@@ -948,7 +982,7 @@ void DevTools(short int nToolNum) {
 }
 
 // A switch-case function for the ColourBackground function.
-void ColourBackgroundSwitch(int* nChoice, std::string* sSettingVariableBack, std::string* sSettingVariable) {
+bool ColourBackgroundSwitch(int* nChoice, std::string* sSettingVariableBack, std::string* sSettingVariable) {
 	// Switch case for selecting colour
 	switch (*nChoice) {
 	case 1:
@@ -1018,16 +1052,17 @@ void ColourBackgroundSwitch(int* nChoice, std::string* sSettingVariableBack, std
 	default:
 		VerbosityDisplay("In ColourBackgroundSwitch() - ERROR: Default switch case statement activated, so nChoice seems to be incorrect.\n");
 		UserErrorDisplay("An error occured, and the colour has not been changed.\nPlease try again later.\n");
-		break;
+		ConfigObjMain.WriteConfigFile();
+		return false;
 	}
 
 	ConfigObjMain.WriteConfigFile();
 
-	return;
+	return true;
 }
 
 // A switch-case function for the ColourForeground function.
-void ColourForegroundSwitch(int* nChoice, std::string* sSettingVariableBack, std::string* sSettingVariable)
+bool ColourForegroundSwitch(int* nChoice, std::string* sSettingVariableBack, std::string* sSettingVariable)
 {
 	// Switch case for selecting colour
 	switch (*nChoice) {
@@ -1098,12 +1133,13 @@ void ColourForegroundSwitch(int* nChoice, std::string* sSettingVariableBack, std
 	default:
 		VerbosityDisplay("In ColourForegroundSwitch() - ERROR: Default switch case statement activated, so nChoice seems to be incorrect.\n");
 		UserErrorDisplay("An error occured, and the colour has not been changed.\nPlease try again later.\n");
-		break;
+		ConfigObjMain.WriteConfigFile();
+		return false;
 	}
 
 	ConfigObjMain.WriteConfigFile();
 
-	return;
+	return true;
 }
 
 // A function that gives an interface to modify the global foreground colour of the terminal.
@@ -1114,22 +1150,22 @@ void ColourForeground(int nChoice = 0) {
 		OptionSelectEngine oseColourFore;
 		oseColourFore.nSizeOfOptions = 17;
 		std::string sOptions[] = {
-			"[1] Black",
-			"[2] Blue",
-			"[3] Green",
-			"[4] Aqua",
-			"[5] Red",
-			"[6] Purple",
-			"[7] Yellow",
-			"[8] White",
-			"[9] Gray",
-			"[10] Light Blue",
-			"[11] Light Green",
-			"[12] Light Aqua",
-			"[13] Light Red",
-			"[14] Light Purple",
-			"[15] Light Yellow",
-			"[16] Bright White (DEFAULT)",
+			"Black",
+			"Blue",
+			"Green",
+			"Aqua",
+			"Red",
+			"Purple",
+			"Yellow",
+			"White",
+			"Gray",
+			"Light Blue",
+			"Light Green",
+			"Light Aqua",
+			"Light Red",
+			"Light Purple",
+			"Light Yellow",
+			"Bright White (DEFAULT)",
 			"Custom RGB Colour Code (Advanced)"
 		};
 		oseColourFore.sOptions = sOptions;
@@ -1244,11 +1280,13 @@ void ColourForeground(int nChoice = 0) {
 		return;
 	}
 
-	ColourForegroundSwitch(&nChoice, &ConfigObjMain.sColourGlobalBack, &ConfigObjMain.sColourGlobal);
+	// Apply foreground colour
+	if (ColourForegroundSwitch(&nChoice, &ConfigObjMain.sColourGlobalBack, &ConfigObjMain.sColourGlobal)) {
+		colour(LGRN, ConfigObjMain.sColourGlobalBack);
+		std::cout << CentreText("Foreground colour successfully set!") << std::endl;
+		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
+	}
 
-	colour(LGRN, ConfigObjMain.sColourGlobalBack);
-	std::cout << CentreText("Foreground colour successfully set!") << std::endl;
-	colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 	return;
 }
 
@@ -1260,22 +1298,22 @@ void ColourBackground(int nChoice = 0) {
 		OptionSelectEngine oseColourBack;
 		oseColourBack.nSizeOfOptions = 17;
 		std::string sOptions[] = {
-			"[1] Black (DEFAULT)",
-			"[2] Blue",
-			"[3] Green",
-			"[4] Aqua",
-			"[5] Red",
-			"[6] Purple",
-			"[7] Yellow",
-			"[8] White",
-			"[9] Gray",
-			"[10] Light Blue",
-			"[11] Light Green",
-			"[12] Light Aqua",
-			"[13] Light Red",
-			"[14] Light Purple",
-			"[15] Light Yellow",
-			"[16] Bright White",
+			"Black (DEFAULT)",
+			"Blue",
+			"Green",
+			"Aqua",
+			"Red",
+			"Purple",
+			"Yellow",
+			"White",
+			"Gray",
+			"Light Blue",
+			"Light Green",
+			"Light Aqua",
+			"Light Red",
+			"Light Purple",
+			"Light Yellow",
+			"Bright White",
 			"Custom RGB Colour Code (Advanced)"
 		};
 		oseColourBack.sOptions = sOptions;
@@ -1388,14 +1426,19 @@ void ColourBackground(int nChoice = 0) {
 		return;
 	}
 
-	ColourBackgroundSwitch(&nChoice, &ConfigObjMain.sColourGlobalBack, &ConfigObjMain.sColourGlobal);
+	// Set background colour
+	if (!ColourBackgroundSwitch(&nChoice, &ConfigObjMain.sColourGlobalBack, &ConfigObjMain.sColourGlobal)) {
+		return;
+	}
+	else {
+		// Apply colours to whole screen
+		cls();
 
-	// Apply colours to whole screen
-	cls();
+		colour(LGRN, ConfigObjMain.sColourGlobalBack);
+		std::cout << CentreText("Background colour successfully set!") << std::endl;
+		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
+	}
 
-	colour(LGRN, ConfigObjMain.sColourGlobalBack);
-	std::cout << CentreText("Background colour successfully set!") << std::endl;
-	colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 	return;
 }
 
@@ -2907,8 +2950,8 @@ bool HackerTyperFile(std::string sFilePath, uint64_t nSpeed = 3) {
 	// Check if the file actually exists
 	std::ifstream FilePathTest(sFinalFilePath);
 	if (FilePathTest.fail()) {
-		VerbosityDisplay("ERROR: In HackerTyperFile() - Test file stream failed to open file path. Incorrect filepath detected.\n");
-		UserErrorDisplay("ERROR - File does not exist. Please ensure the filepath that has been used exists, and try again later.\n");
+		VerbosityDisplay("ERROR: In HackerTyperFile() - Test file stream failed to open file path. Incorrect filepath, lack of permissions, bad memory, etc could be the culprit.\n");
+		UserErrorDisplay("ERROR - File does not exist. Please ensure the filepath that has been used exists, the permissions are there and there is enough system memory, and try again later.\n");
 		FilePathTest.close();
 		return false;
 	}

--- a/CommandFiles/CommandHelpMessages.cpp
+++ b/CommandFiles/CommandHelpMessages.cpp
@@ -7,8 +7,10 @@ namespace helpmsgs
 	// Help
 	void HelpHelp() {
 		CentreColouredText(" ___HELP___ ", 1);
-
 		std::cout << '\n';
+		CentreColouredText("This command displays all the commands that are in ZeeTerminal.", 2);
+		std::cout << "\n\n";
+
 		colourSubheading();
 		std::cout << "What this command does:" << NOULINE_STR;
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
@@ -26,8 +28,10 @@ namespace helpmsgs
 	// Tutorial
 	void TutorialHelp() {
 		CentreColouredText(" ___TUTORIAL___ ", 1);
-
 		std::cout << '\n';
+		CentreColouredText("This command provides an interface to access a tutorial about ZeeTerminal.", 2);
+		std::cout << "\n\n";
+
 		colourSubheading();
 		std::cout << "What this command does:" << NOULINE_STR;
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
@@ -64,8 +68,10 @@ namespace helpmsgs
 	// Cls
 	void ClsHelp() {
 		CentreColouredText(" ___CLS___ ", 1);
-
 		std::cout << '\n';
+		CentreColouredText("This command allows you to clear the screen of ZeeTerminal.", 2);
+		std::cout << "\n\n";
+
 		colourSubheading();
 		std::cout << "What this command does:" << NOULINE_STR;
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
@@ -82,8 +88,10 @@ namespace helpmsgs
 	// DevTools
 	void DevToolsHelp() {
 		CentreColouredText(" ___DEVTOOLS___ ", 1);
-
 		std::cout << '\n';
+		CentreColouredText("This command provides an interface to test features of ZeeTerminal.", 2);
+		std::cout << "\n\n";
+
 		colourSubheading();
 		std::cout << "What this command does:" << NOULINE_STR;
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
@@ -109,6 +117,7 @@ namespace helpmsgs
 
 	// CpuStress
 	void CpuStressHelp() {
+		// Title is already outputted
 		CentreColouredText("CPUStress can stress or benchmark your CPU in multiple different ways.", 2);
 		std::cout << "\n\n";
 
@@ -134,8 +143,10 @@ namespace helpmsgs
 	// Colour
 	void ColourHelp() {
 		CentreColouredText(" ___COLOUR___ ", 1);
-
 		std::cout << '\n';
+		CentreColouredText("This command provides an interface to change the colour of ZeeTerminal.", 2);
+		std::cout << "\n\n";
+
 		colourSubheading();
 		std::cout << "What this command does:" << NOULINE_STR;
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
@@ -160,8 +171,10 @@ namespace helpmsgs
 	// Settings
 	void SettingsHelp() {
 		CentreColouredText(" ___SETTINGS___ ", 1);
-
 		std::cout << '\n';
+		CentreColouredText("This command allows you to tweak ZeeTerminal to your liking.", 2);
+		std::cout << "\n\n";
+
 		colourSubheading();
 		std::cout << "What this command does:" << NOULINE_STR;
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
@@ -218,7 +231,7 @@ namespace helpmsgs
 		colourSubheading();
 		std::cout << "What this command does:" << NOULINE_STR;
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
-		std::cout << wordWrap("\n- This command allows you to set the title of this window, which is the window running ZeeTerminal.\n- The title can only be a maximum of 254 characters.\n\n");
+		std::cout << wordWrap("\n- This command allows you to set the title of this window, which is the window running ZeeTerminal.\n- The title can only be a maximum of 65535 characters.\n\n");
 
 		colourSubheading();
 		std::cout << "Possible arguments for this command:" << NOULINE_STR;
@@ -231,8 +244,10 @@ namespace helpmsgs
 	// Date
 	void DateHelp() {
 		CentreColouredText(" ___DATE___ ", 1);
-
 		std::cout << '\n';
+		CentreColouredText("This command displays the date and time of this computer.", 2);
+		std::cout << "\n\n";
+
 		colourSubheading();
 		std::cout << "What this command does:" << NOULINE_STR;
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
@@ -249,6 +264,10 @@ namespace helpmsgs
 
 	// ColourNumbers
 	void ColourNumbersHelp() {
+		// Title is already outputted
+		CentreColouredText("This command displays the colour numbers for all default colours in ZeeTerminal.", 2);
+		std::cout << "\n\n";
+
 		colourSubheading();
 		std::cout << "What this command does:" << NOULINE_STR;
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
@@ -265,6 +284,10 @@ namespace helpmsgs
 
 	// MediaPlayer
 	void MediaPlayerHelp() {
+		// Title is already outputted
+		CentreColouredText("This command allows you to play specific media files of your choice using the DirectShow API.", 2);
+		std::cout << "\n\n";
+
 		colourSubheading();
 		std::cout << "What this command does: " << NOULINE_STR;
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
@@ -276,7 +299,7 @@ namespace helpmsgs
 		std::cout << "Possible arguments for this command: " << NOULINE_STR;
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 		std::cout << wordWrap("\n -h\tDisplays this help message.")
-			<< wordWrap("\n <FILE>\tOpens a file for playback/viewing. Put the exact filepath in place of <FILE>.\n\nExample: mediaplayer \"C:\\Media\\media test.mp3\"\n\n")
+			<< wordWrap("\n <FILE>\tOpens a file for playback/viewing. Put the exact filepath in place of <FILE>.\n\nExample: mediaplayer \"C:\\Media\\media test.mp3\"\n")
 			<< wordWrap("\nNOTE: You need to use quotes like shown in the example to use a filename with ANY spaces.\nNOTE: Type in \"*open\" without quotes in place of the file argument to use the Windows File Dialogue to open a file.\n\n");
 
 		return;
@@ -284,10 +307,14 @@ namespace helpmsgs
 
 	// AudioPlayer
 	void AudioPlayerHelp() {
+		// Title is already outputted
+		CentreColouredText("This command allows you to play an audio file using the BASS Audio Libraries.", 2);
+		std::cout << "\n\n";
+
 		colourSubheading();
 		std::cout << "What this command does:" << NOULINE_STR;
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
-		std::cout << wordWrap("\n- Plays a wide range of popular audio formats, such as FLAC and MP3, in an easy-to-use interface.\n- This is newer than the MediaPlayer, which uses an older DirectShow API.\n- Uses the BASS Audio API, so requires DLLs to be in the same directory as ZeeTerminal.\n- Audio formats supported: MP3, MP2, MP1, OGG, WAV, AIFF, FLAC, XM, IT, S3M, MOD, MTM, UMX, WMA, M4A, OPUS, AAC\n\n");
+		std::cout << wordWrap("\n- Plays a wide range of popular audio formats, such as FLAC and MP3, in an easy-to-use interface.\n- This is newer than the MediaPlayer, which uses an older DirectShow API.\n- Uses the BASS Audio API, so requires DLLs to be in the same directory as ZeeTerminal.\n- Audio formats supported: MP3, MP2, MP1, OGG, WAV, AIFF, FLAC, XM, IT, S3M, MOD, MTM, UMX, WMA, M4A, OPUS and AAC.\n\n");
 
 		colourSubheading();
 		std::cout << "Possible arguments for this command:" << NOULINE_STR;
@@ -313,8 +340,8 @@ namespace helpmsgs
 		std::cout << "Possible arguments for this command: " << NOULINE_STR;
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 		std::cout << wordWrap("\n -h\tDisplays this help message.\n <MSG>\tInput text to be said by the computer. Put text in place of <MSG>.\n\n")
-			<< wordWrap("Example: tts \"The quick brown fox jumps over the lazy dog.\"\n\n")
-			<< wordWrap("Note: If the text contains any spaces, put it in speech marks like the example, or it will not work.\n\n");
+			<< wordWrap("Example: tts \"The quick brown fox jumps over the lazy dog.\"\n")
+			<< wordWrap("\nNote: If the text contains any spaces, put it in speech marks like the example, or it will not work.\n\n");
 
 		return;
 	}
@@ -362,13 +389,14 @@ namespace helpmsgs
 
 	// Timer
 	void TimerHelp() {
+		// Title is already outputted
 		CentreColouredText("This is a highly accurate countdown timer that counts time in seconds.", 2);
 		std::cout << "\n\n";
 
 		colourSubheading();
 		std::cout << "What this command does:" << NOULINE_STR;
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
-		std::cout << wordWrap("\n- Provides access to a highly accurate countdown timer that takes time in seconds.\n- You can press any key to exit the timer while in operation.\n\n");
+		std::cout << wordWrap("\n- Provides access to a highly accurate countdown timer that takes time in seconds.\n- You can press the ESC key to exit the timer while in operation.\n\n");
 		colourSubheading();
 		std::cout << "Possible arguments for this command:" << NOULINE_STR;
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
@@ -424,7 +452,7 @@ namespace helpmsgs
 	void CopyFileHelp() {
 		CentreColouredText(" ___COPYFILE___ ", 1);
 		std::cout << "\n";
-		CentreColouredText("This command copies a file from one location to another.", 2);
+		CentreColouredText("This command copies the contents of a file to another file.", 2);
 		std::cout << "\n\n";
 
 		colourSubheading();
@@ -465,7 +493,7 @@ namespace helpmsgs
 		std::cout << wordWrap("\n -h\t\tDisplays this help message.\n -o\t\tEnable overwrite mode. Any existing file with the same filename as the file to copy will be overwritten when specified."
 			"\n -d\t\tEnable folder copy mode. When a folder is specified as a source, the contents of that folder will be recursively copied to the destination."
 			"\n <source>\tThe file to copy. Put the file directory in place of <source>.\n <dest>\t\tThe destination location/directory. Put the directory path in place of <dest>.\n\n"
-			"Syntax: copy <source <dest> (in this exact order).\n\n"
+			"Syntax: copy <source> <dest> (in this exact order).\n\n"
 			"Example: copy \"C:\\test\\a file.txt\" C:\\Users\n\n"
 			"NOTE: For any directory with spaces, use quotes like in the example.\nNOTE: You must have both the source and the destination directories when using them as arguments.\nNOTE: Read this article for information on the different forms of filepaths: ");
 
@@ -499,9 +527,10 @@ namespace helpmsgs
 
 	// ConfigAction
 	void ConfigActionHelp() {
-		std::cout << '\n';
 		CentreColouredText(" ___CONFIGACTION___ ", 1);
 		std::cout << '\n';
+		CentreColouredText("This command provides an interface to interact with the Config File System.", 2);
+		std::cout << "\n\n";
 
 		colourSubheading();
 		std::cout << "What this command does:" << NOULINE_STR;
@@ -522,6 +551,8 @@ namespace helpmsgs
 	void BeepSoundsHelp() {
 		CentreColouredText(" ___BEEPSOUNDS___ ", 1);
 		std::cout << '\n';
+		CentreColouredText("This command allows you to access a wide range of iconic sounds encoded in beeps.", 2);
+		std::cout << "\n\n";
 
 		colourSubheading();
 		std::cout << "What this command does:" << NOULINE_STR;
@@ -543,6 +574,8 @@ namespace helpmsgs
 		std::cout << '\n';
 		CentreColouredText(" ___RICKROLL___ ", 1);
 		std::cout << '\n';
+		CentreColouredText("This command allows you to continue the age-old meme of rickrolling.", 2);
+		std::cout << "\n\n";
 
 		colourSubheading();
 		std::cout << "What this command does:" << NOULINE_STR;
@@ -559,7 +592,7 @@ namespace helpmsgs
 
 	// ShellExecute
 	void ShellExecuteHelp() {
-		CentreColouredText("___SHELLEXECUTE___", 1);
+		CentreColouredText(" ___SHELLEXECUTE___ ", 1);
 		std::cout << "\n";
 		CentreColouredText("This allows for the execution of CMD shell commands from ZeeTerminal.", 2);
 		std::cout << "\n\n";
@@ -582,6 +615,8 @@ namespace helpmsgs
 	void HackerHelp() {
 		CentreColouredText(" ___HACKER___ ", 1);
 		std::cout << '\n';
+		CentreColouredText("This command provides a number of features to make you look like a hacker.", 2);
+		std::cout << "\n\n";
 
 		colourSubheading();
 		std::cout << "What this command does:" << NOULINE_STR;
@@ -650,6 +685,8 @@ namespace helpmsgs
 	void LogoffHelp() {
 		CentreColouredText(" ___LOGOFF___ ", 1);
 		std::cout << '\n';
+		CentreColouredText("This command provides an interface to log off from your computer.", 2);
+		std::cout << "\n\n";
 
 		colourSubheading();
 		std::cout << "What this command does:" << NOULINE_STR;
@@ -668,6 +705,8 @@ namespace helpmsgs
 	void ShutdownHelp() {
 		CentreColouredText(" ___SHUTDOWN___ ", 1);
 		std::cout << '\n';
+		CentreColouredText("This command provides an interface to shutdown your computer.", 2);
+		std::cout << "\n\n";
 
 		colourSubheading();
 		std::cout << "What this command does:" << NOULINE_STR;
@@ -678,7 +717,7 @@ namespace helpmsgs
 		std::cout << "Possible arguments for this command:" << NOULINE_STR;
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 		std::cout << wordWrap("\n -h\t\tDisplays this help message.\n -t <time>\tA time argument for shutdown in seconds. Put time argument in place of <time>. Must be a number.\n -c\t\tCancel any pending shutdown operations.")
-			<< wordWrap("\n\nExample: shutdown -t 5\n\n");
+			<< wordWrap("\n\nExample: shutdown -t 10\n\n");
 
 		return;
 	}
@@ -687,6 +726,8 @@ namespace helpmsgs
 	void RebootHelp() {
 		CentreColouredText(" ___REBOOT___ ", 1);
 		std::cout << '\n';
+		CentreColouredText("This command provides an interface to reboot your computer.", 2);
+		std::cout << "\n\n";
 
 		colourSubheading();
 		std::cout << "What this command does:" << NOULINE_STR;
@@ -697,7 +738,7 @@ namespace helpmsgs
 		std::cout << "Possible arguments for this command:" << NOULINE_STR;
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 		std::cout << wordWrap("\n -h\t\tDisplays this help message.\n -t <time>\tA time argument for reboot in seconds. Put time argument in place of <time>. Must be a number.\n -c\t\tCancel any pending reboot operations.")
-			<< wordWrap("\n\nExample: reboot -t 5\n\n");
+			<< wordWrap("\n\nExample: reboot -t 10\n\n");
 
 		return;
 	}
@@ -706,6 +747,8 @@ namespace helpmsgs
 	void HibernateHelp() {
 		CentreColouredText(" ___HIBERNATE___ ", 1);
 		std::cout << '\n';
+		CentreColouredText("This command provides an interface to hibernate your computer.", 2);
+		std::cout << "\n\n";
 
 		colourSubheading();
 		std::cout << "What this command does:" << NOULINE_STR;
@@ -713,7 +756,7 @@ namespace helpmsgs
 		std::cout << wordWrap("\n- Hibernates the computer that ZeeTerminal is running on.\n- Initiating the hibernate process is immediate and on command.\n- Hibernation will NOT work if hibernation is disabled on the computer running ZeeTerminal.\n\n");
 
 		colourSubheading();
-		std::cout << "What this command does:" << NOULINE_STR;
+		std::cout << "Possible arguments for this command:" << NOULINE_STR;
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 		std::cout << wordWrap("\n -h\tDisplays this help message.\n\nExample: hibernate -h\n\n");
 
@@ -724,6 +767,8 @@ namespace helpmsgs
 	void ResetExplHelp() {
 		CentreColouredText(" ___RESETEXPL___ ", 1);
 		std::cout << '\n';
+		CentreColouredText("This command allows you to reset Explorer.exe quickly and easily.", 2);
+		std::cout << "\n\n";
 
 		colourSubheading();
 		std::cout << "What this command does:" << NOULINE_STR;
@@ -742,6 +787,8 @@ namespace helpmsgs
 	void MemTestHelp() {
 		CentreColouredText(" ___MEMTEST___ ", 1);
 		std::cout << '\n';
+		CentreColouredText("This command allows you to quickly test your computer's memory for issues.", 2);
+		std::cout << "\n\n";
 
 		colourSubheading();
 		std::cout << "What this command does:" << NOULINE_STR;
@@ -755,7 +802,7 @@ namespace helpmsgs
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 		std::cout << wordWrap("\n -h\t\tDisplays this help message.\n -f\t\tSimply fill up and allocate the system memory, and then deallocate.\n -b <passes>\tPerform binary searches on allocated memory. Put number of passes in place of <passes>.")
 			<< wordWrap("\n -l <passes>\tPerform linear check searches on allocated memory. Put number of passes in place of <passes>.\n -e <passes>\tPerform extended linear check searches on allocated memory. Put number of passes in place of <passes>.\n -k\t\tRequire a keypress before memory deallocation, with the -f option. Default is false.")
-			<< wordWrap("\n -m\t\tUse multithreading. May increase performance but can increase CPU temperatures.\n -a\t\tUse all the memory available on the host system, rather than just the default available memory. May not work with systems that have paging disabled.\n\nExample: memtest -k -l 6\n\n");
+			<< wordWrap("\n -m\t\tUse multithreading. May increase performance but can increase CPU temperatures. Default is FALSE.\n -a\t\tUse all the memory available on the host system, rather than just the default available memory. May not work with systems that have paging disabled.\n\nExample: memtest -k -l 6\n\n");
 
 		return;
 	}
@@ -764,6 +811,8 @@ namespace helpmsgs
 	void RandColHelp() {
 		CentreColouredText(" ___RANDCOL___ ", 1);
 		std::cout << '\n';
+		CentreColouredText("This command allows you to randomly pick a colour for ZeeTerminal.", 2);
+		std::cout << "\n\n";
 
 		colourSubheading();
 		std::cout << "What this command does:" << NOULINE_STR;
@@ -782,6 +831,8 @@ namespace helpmsgs
 	void PauseHelp() {
 		CentreColouredText(" ___PAUSE___ ", 1);
 		std::cout << '\n';
+		CentreColouredText("This command allows you to pause the operation of ZeeTerminal until any key/ENTER is pressed.", 2);
+		std::cout << "\n\n";
 
 		colourSubheading();
 		std::cout << "What this command does:" << NOULINE_STR;
@@ -800,6 +851,8 @@ namespace helpmsgs
 	void CommandNumHelp() {
 		CentreColouredText(" ___COMMANDNUM___ ", 1);
 		std::cout << '\n';
+		CentreColouredText("This command displays the statistics of the commands you have inputted since ZeeTerminal startup.", 2);
+		std::cout << "\n\n";
 
 		colourSubheading();
 		std::cout << "What this command does:" << NOULINE_STR;
@@ -818,6 +871,8 @@ namespace helpmsgs
 	void SlowCharHelp() {
 		CentreColouredText(" ___SLOWCHAR___ ", 1);
 		std::cout << '\n';
+		CentreColouredText("This command allows you to slowly output a string.", 2);
+		std::cout << "\n\n";
 
 		colourSubheading();
 		std::cout << "What this command does:" << NOULINE_STR;
@@ -837,6 +892,8 @@ namespace helpmsgs
 	void ReverseTextHelp() {
 		CentreColouredText(" ___REVERSETEXT___ ", 1);
 		std::cout << '\n';
+		CentreColouredText("This command provides an interface to output a string in reverse.", 2);
+		std::cout << "\n\n";
 
 		colourSubheading();
 		std::cout << "What this command does:" << NOULINE_STR;
@@ -899,6 +956,8 @@ namespace helpmsgs
 	void DispHelp() {
 		CentreColouredText(" ___DISP___ ", 1);
 		std::cout << "\n";
+		CentreColouredText("This command provides an interface to toggle displaying the command input screen.", 2);
+		std::cout << "\n\n";
 
 		colourSubheading();
 		std::cout << "What this command does:" << NOULINE_STR;
@@ -918,6 +977,10 @@ namespace helpmsgs
 
 	// SysInfo
 	void SysInfoHelp() {
+		// Title is already outputted
+		CentreColouredText("This command displays the system information of your computer.", 2);
+		std::cout << "\n\n";
+
 		colourSubheading();
 		std::cout << "What this command does:" << NOULINE_STR;
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
@@ -1092,6 +1155,7 @@ namespace helpmsgs
 		std::cout << '\n';
 		CentreColouredText("This command allows you to easily encrypt or decrypt files and folders on your computer.", 2);
 		std::cout << "\n\n";
+
 		colourSubheading();
 		std::cout << "What this command does:" << NOULINE_STR;
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
@@ -1203,7 +1267,7 @@ namespace helpmsgs
 		colourSubheading();
 		std::cout << "What this command does:" << NOULINE_STR;
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
-		std::cout << wordWrap("\n- This command outputs an argument-specified number of digits of Pi, up to 1 million decimal places.\n- For speed and efficiency purposes, the number is truncated, not rounded up or down.\n- For speed and simplistic purposes, the value of Pi is not calculated at run-time, however it was hard-coded at the compile-time of this program."
+		std::cout << wordWrap("\n- This command outputs an argument-specified number of digits of Pi, up to 1 million decimal places.\n- For speed and efficiency purposes, the number is truncated, not rounded up or down.\n- For speed and simplistic purposes, the value of Pi is not calculated at run-time, however it was hard-coded at the compile-time of ZeeTerminal."
 			"\n- You can learn more about Pi here: ");
 		colour(LBLU, ConfigObjMain.sColourGlobalBack);
 		std::cout << wordWrap("https://en.wikipedia.org/wiki/Pi\n\n");

--- a/CommandFiles/CommandsFiles/CommandsFile_11to20.cpp
+++ b/CommandFiles/CommandsFiles/CommandsFile_11to20.cpp
@@ -18,6 +18,7 @@ bool commands::Commands11To20(const std::string sCommand, char* cCommandArgs, co
 			}
 		}
 
+		// Get the current time and initialise time structure
 		time_t currentTime = time(0);
 		struct tm localTime {};
 
@@ -28,15 +29,15 @@ bool commands::Commands11To20(const std::string sCommand, char* cCommandArgs, co
 		std::cout << "Current Date/Time Info:" << NOULINE_STR;
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 
-
+		// Use std::put_time to output time in formatted manner
 		std::cout << "\n\nLocal Date: ";
 		colour(LCYN, ConfigObjMain.sColourGlobalBack);
-		std::cout << localTime.tm_mday << "/" << (localTime.tm_mon + 1) << "/" << (localTime.tm_year + 1900); 
+		std::cout << std::put_time(&localTime, "%d/%m/%Y");
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 		std::cout << " (DD/MM/YYYY)\n";
 		std::cout << "Local Time: ";
 		colour(LCYN, ConfigObjMain.sColourGlobalBack);
-		std::cout << localTime.tm_hour << ":" << localTime.tm_min << ":" << localTime.tm_sec << "\n";
+		std::cout << std::put_time(&localTime, "%H:%M:%S\n");
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 
 		return true;
@@ -125,7 +126,7 @@ bool commands::Commands11To20(const std::string sCommand, char* cCommandArgs, co
 		}
 
 		// Execute multimedia player with the inputted file path
-		VerbosityDisplay("Executing media file using MediaPlayer: \"" + ws2s(wsFilePath) + "\"...\n");
+		VerbosityDisplay("In commands::Commands11To20(): INFO - Executing media file using MediaPlayer: \"" + ws2s(wsFilePath) + "\"...\n");
 		MultimediaEngine meMediaPlayer;
 		meMediaPlayer.DShowMultimediaPlayer(wsFilePath);
 
@@ -137,7 +138,7 @@ bool commands::Commands11To20(const std::string sCommand, char* cCommandArgs, co
 	else if (sCommand == "audioplayer" || sCommand == "14") {
 		std::string sFilePath = "";
 
-		CentreColouredText("___AUDIO PLAYER___", 1);
+		CentreColouredText(" ___AUDIOPLAYER___ ", 1);
 		std::cout << '\n';
 
 		// Arguments Interface
@@ -157,7 +158,7 @@ bool commands::Commands11To20(const std::string sCommand, char* cCommandArgs, co
 			colourSubheading();
 			std::cout << wordWrap("The following file formats are supported:") << NOULINE_STR;
 			colour(LCYN, ConfigObjMain.sColourGlobalBack);
-			std::cout << wordWrap("\nMP3, MP2, MP1, OGG, WAV, AIFF, FLAC, XM, IT, S3M, MOD, MTM, UMX, WMA, M4A, OPUS, AAC\n\nType \"*open\" without quotes to use the Windows File Dialogue to open an audio file.\n");
+			std::cout << wordWrap("\nMP3, MP2, MP1, OGG, WAV, AIFF, FLAC, XM, IT, S3M, MOD, MTM, UMX, WMA, M4A, OPUS and AAC.\n\nType \"*open\" without quotes to use the Windows File Dialogue to open an audio file.\n");
 			colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 
 			// Prompt
@@ -185,7 +186,7 @@ bool commands::Commands11To20(const std::string sCommand, char* cCommandArgs, co
 			}
 		}
 
-		VerbosityDisplay("Executing audio file using AudioPlayer: \"" + sStringDataCommandArgs[0] + "\"...\n");
+		VerbosityDisplay("In commands::Commands11To20(): INFO - Executing audio file using AudioPlayer: \"" + sStringDataCommandArgs[0] + "\"...\n");
 		MultimediaEngine meAudioPlayer;
 		meAudioPlayer.BASSAudioPlayer(sFilePath);
 
@@ -371,10 +372,10 @@ bool commands::Commands11To20(const std::string sCommand, char* cCommandArgs, co
 			size_t nFinalMarkPos = sFilePath.find('\"', nFirstMarkPos) - 1;
 			sFilePath = sFilePath.substr(nFirstMarkPos, nFinalMarkPos);
 		}
-
+		
 		fileTestIn.open(sFilePath);
 		if (fileTestIn.fail()) {
-			VerbosityDisplay("In Commands() - ERROR: Unknown directory/file detected. Read operation failed.\n");
+			VerbosityDisplay("In commands::Commands11To20() - ERROR: Unknown directory/file detected. Read operation failed.\n");
 			UserErrorDisplay("ERROR - The directory or file doesn't exist. Please try again with a directory/file that exists.\n");
 
 			fileTestIn.close();
@@ -439,7 +440,7 @@ bool commands::Commands11To20(const std::string sCommand, char* cCommandArgs, co
 			else if (sStringDataCommandArgs[0] != "") {
 				// Firstly, check if argument is a real and usable number
 				if (isNumberld(sStringDataCommandArgs[0]) == false) {
-					VerbosityDisplay("In Commands() - ERROR: Could not detect numerical value in string-based number argument.\n");
+					VerbosityDisplay("In commands::Commands11To20() - ERROR: Could not detect numerical value in string-based number argument.\n");
 					UserErrorDisplay("ERROR - Number argument is either too big or not a number.\nPlease try again with a number between 0 and 2 billion.\n");
 
 					return true;
@@ -464,7 +465,7 @@ bool commands::Commands11To20(const std::string sCommand, char* cCommandArgs, co
 
 		// Start timer with prompts
 		colour(LBLU, ConfigObjMain.sColourGlobalBack);
-		std::cout << wordWrap("\nPress any key to exit the timer.\n\n");
+		std::cout << wordWrap("\nPress ESC to exit the timer.\n\n");
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 
 		// Disable cursor visibility
@@ -538,7 +539,7 @@ bool commands::Commands11To20(const std::string sCommand, char* cCommandArgs, co
 			if (sStringDataCommandArgs[0] != "") {
 				// Firstly, check if argument is a real and usable number
 				if (isNumberld(sStringDataCommandArgs[0]) == false) {
-					VerbosityDisplay("In Commands() - ERROR: Could not detect numerical value in string-based number argument.\n");
+					VerbosityDisplay("In commands::Commands11To20() - ERROR: Could not detect numerical value in string-based number argument.\n");
 					UserErrorDisplay("ERROR - Your frequency argument is either too big or not a number.\nPlease try again with a number between 0 and 2 billion.\n");
 
 					return true;
@@ -548,7 +549,7 @@ bool commands::Commands11To20(const std::string sCommand, char* cCommandArgs, co
 				dFrequency = std::stold(sStringDataCommandArgs[0]);
 
 				if (dFrequency < 0) {
-					VerbosityDisplay("ERROR: In Commands() - Numerical value argument incorrect (negative number).\n");
+					VerbosityDisplay("ERROR: In commands::Commands11To20() - Numerical value argument incorrect (negative number).\n");
 					UserErrorDisplay("ERROR - Your frequency argument is a negative number.\nPlease try again with a number between 0 and 2 billion.\n");
 
 					return true;
@@ -559,7 +560,7 @@ bool commands::Commands11To20(const std::string sCommand, char* cCommandArgs, co
 			if (sStringDataCommandArgs[1] != "") {
 				// Firstly, check if argument is a real and usable number
 				if (isNumberld(sStringDataCommandArgs[1]) == false) {
-					VerbosityDisplay("In Commands() - ERROR: Could not detect numerical value in string-based number argument.\n");
+					VerbosityDisplay("In commands::Commands11To20() - ERROR: Could not detect numerical value in string-based number argument.\n");
 					UserErrorDisplay("ERROR - Your time argument is either too big or not a number.\nPlease try again with a number between 0 and 2 billion.\n");
 
 					return true;
@@ -570,7 +571,7 @@ bool commands::Commands11To20(const std::string sCommand, char* cCommandArgs, co
 
 				// Negative numbers are not allowed.
 				if (dDuration < 0) {
-					VerbosityDisplay("ERROR: In Commands() - Numerical value argument incorrect (negative number).\n");
+					VerbosityDisplay("ERROR: In commands::Commands11To20() - Numerical value argument incorrect (negative number).\n");
 					UserErrorDisplay("ERROR - Your time argument is a negative number.\nPlease try again with a number between 0 and 2 billion.\n");
 
 					return true;
@@ -635,7 +636,7 @@ bool commands::Commands11To20(const std::string sCommand, char* cCommandArgs, co
 					sText = sStringDataCommandArgs[i];
 				}
 				else {
-					VerbosityDisplay("ERROR: In Commands() - Vital argument not found.\n");
+					VerbosityDisplay("ERROR: In commands::Commands11To20() - Vital argument not found.\n");
 					UserErrorDisplay("ERROR - No form of text argument found.\nPlease make sure that's there, and try again.\n");
 
 					return true;
@@ -647,7 +648,7 @@ bool commands::Commands11To20(const std::string sCommand, char* cCommandArgs, co
 					sCaption = sStringDataCommandArgs[i];
 				}
 				else {
-					VerbosityDisplay("ERROR: In Commands() - Vital argument not found.\n");
+					VerbosityDisplay("ERROR: In commands::Commands11To20() - Vital argument not found.\n");
 					UserErrorDisplay("ERROR - No form of caption text argument found.\nPlease make sure that's there, and try again.\n");
 
 					return true;
@@ -660,7 +661,7 @@ bool commands::Commands11To20(const std::string sCommand, char* cCommandArgs, co
 					if (nIcon == 1) return true;
 				}
 				else {
-					VerbosityDisplay("ERROR: In Commands() - Vital argument not found.\n");
+					VerbosityDisplay("ERROR: In commands::Commands11To20() - Vital argument not found.\n");
 					UserErrorDisplay("ERROR - No form of icon argument found.\nPlease make sure that's there, and try again.\n");
 
 					return true;
@@ -671,7 +672,7 @@ bool commands::Commands11To20(const std::string sCommand, char* cCommandArgs, co
 					nButton = MessageBoxButtonSwitch(sStringDataCommandArgs[i]);
 				}
 				else {
-					VerbosityDisplay("ERROR: In Commands() - Vital argument not found.\n");
+					VerbosityDisplay("ERROR: In commands::Commands11To20() - Vital argument not found.\n");
 					UserErrorDisplay("ERROR - No form of button argument found.\nPlease make sure that's there, and try again.\n");
 
 					return true;
@@ -758,7 +759,7 @@ bool commands::Commands11To20(const std::string sCommand, char* cCommandArgs, co
 
 		if (MessageBoxA(NULL, sText.c_str(), sCaption.c_str(), nButton | nIcon) == false) {
 			// An error occured
-			VerbosityDisplay("In Commands() - ERROR: Possible unknown messagebox return value from OptionSelectEngine::OptionSelect(), or standard WIN32 Function Library error.\n");
+			VerbosityDisplay("In commands::Commands11To20() - ERROR: Possible unknown messagebox return value from OptionSelectEngine::OptionSelect(), or standard WIN32 Function Library error.\n");
 			UserErrorDisplay("An error occured while displaying the message box.\nPlease try again later.\n");
 		}
 		else {

--- a/CommandFiles/CommandsFiles/CommandsFile_1to10.cpp
+++ b/CommandFiles/CommandsFiles/CommandsFile_1to10.cpp
@@ -39,6 +39,9 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 			}
 		}
 
+		CentreColouredText(" ___TUTORIAL___ ", 1);
+		std::cout << "\n";
+
 		// Start the tutorial
 		if (YesNoInput("Are you sure you want to start the tutorial? [y/n] > ")) {
 			Tutorial();
@@ -65,8 +68,13 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 			sEchoString += sStringDataCommandArgs[i];
 		}
 
+
+
 		// Output what user wants to input within echo
 		if (sEchoString == "") {
+			CentreColouredText(" ___ECHO___ ", 1);
+			std::cout << "\n";
+
 			sEchoString = StrInput("Input what you would like ZeeTerminal to echo (output): > ");
 
 			// Output the input
@@ -197,7 +205,7 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 				DevTools(9);
 				break;
 			default:
-				VerbosityDisplay("In Commands() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
+				VerbosityDisplay("In commands::Commands1To10() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
 				UserErrorDisplay("ERROR - Unknown error occured. Please try again later.\n");
 				break;
 			}
@@ -294,7 +302,7 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 				return true;
 			}
 			else {
-				VerbosityDisplay("In Commands() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
+				VerbosityDisplay("In commands::Commands1To10() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
 				UserErrorDisplay("ERROR - Unknown error occured. Please try again later.\n");
 
 				return true;
@@ -327,7 +335,7 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 				}
 				else {
 					// Can't process a non-number
-					VerbosityDisplay("In Commands() - ERROR: Could not detect numerical value in string-based number argument.\n");
+					VerbosityDisplay("In commands::Commands1To10() - ERROR: Could not detect numerical value in string-based number argument.\n");
 					UserErrorDisplay("An error occured while processing your foreground argument. Make sure your argument syntax is correct, and try again.\nSee \"colour -h\" for more info.\n");
 					Exiting();
 					return true;
@@ -344,7 +352,7 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 				}
 				else {
 					// Can't process a non-number
-					VerbosityDisplay("In Commands() - ERROR: Could not detect numerical value in string-based number argument.\n");
+					VerbosityDisplay("In commands::Commands1To10() - ERROR: Could not detect numerical value in string-based number argument.\n");
 					UserErrorDisplay("An error occured while processing your background argument. Make sure your argument syntax is correct, and try again.\nSee \"colour -h\" for more info.\n");
 					Exiting();
 					return true;
@@ -429,7 +437,7 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 				break;
 			}
 			else {
-				VerbosityDisplay("In Commands() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
+				VerbosityDisplay("In commands::Commands1To10() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
 				UserErrorDisplay("ERROR - Unknown error occured. Please try again later.\n");
 				return true;
 			}
@@ -451,10 +459,17 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 
 				// Check if argument is a number, post error message if not and call function if yes
 				if (isNumberi(sStringDataCommandArgs[0])) {
+					// Check if colour number is beyond limits - alert user if so
+					if (std::stoi(sStringDataCommandArgs[0]) < 1 || std::stoi(sStringDataCommandArgs[0]) > 16) {
+						VerbosityDisplay("In commands::Commands1To10() - ERROR: The colour number specified is beyond the acceptable colour number range (1 <= x <= 16).");
+						UserErrorDisplay("ERROR - The specified colour number argument is less than 1 or above 16. Please ensure that the argument is within the acceptable range, and try again later.\n");
+						return true;
+					}
+
 					HighlightColourSettings(1, std::stoi(sStringDataCommandArgs[0]));
 				}
 				else {
-					VerbosityDisplay("In Commands() - ERROR: Could not detect numerical value in string-based number argument.\n");
+					VerbosityDisplay("In commands::Commands1To10() - ERROR: Could not detect numerical value in string-based number argument.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's a number and try again.\nType \"settings -h\" for more info.\n");
 				}
 
@@ -462,10 +477,17 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 			}
 			else if (sStringOptionCommandArgs[0] == "highlightback") {
 				if (isNumberi(sStringDataCommandArgs[0])) {
+					// Check if colour number is beyond limits - alert user if so
+					if (std::stoi(sStringDataCommandArgs[0]) < 1 || std::stoi(sStringDataCommandArgs[0]) > 16) {
+						VerbosityDisplay("In commands::Commands1To10() - ERROR: The colour number specified is beyond the acceptable colour number range (1 <= x <= 16).");
+						UserErrorDisplay("ERROR - The specified colour number argument is less than 1 or above 16. Please ensure that the argument is within the acceptable range, and try again later.\n");
+						return true;
+					}
+
 					HighlightColourSettings(2, std::stoi(sStringDataCommandArgs[0]));
 				}
 				else {
-					VerbosityDisplay("In Commands() - ERROR: Could not detect numerical value in string-based number argument.\n");
+					VerbosityDisplay("In commands::Commands1To10() - ERROR: Could not detect numerical value in string-based number argument.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's a number and try again.\nType \"settings -h\" for more info.\n");
 				}
 
@@ -473,40 +495,68 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 			}
 			else if (sStringOptionCommandArgs[0] == "titlefore") {
 				if (isNumberi(sStringDataCommandArgs[0])) {
+					// Check if colour number is beyond limits - alert user if so
+					if (std::stoi(sStringDataCommandArgs[0]) < 1 || std::stoi(sStringDataCommandArgs[0]) > 16) {
+						VerbosityDisplay("In commands::Commands1To10() - ERROR: The colour number specified is beyond the acceptable colour number range (1 <= x <= 16).");
+						UserErrorDisplay("ERROR - The specified colour number argument is less than 1 or above 16. Please ensure that the argument is within the acceptable range, and try again later.\n");
+						return true;
+					}
+
 					TitleColourSettings(1, std::stoi(sStringDataCommandArgs[0]));
 				}
 				else {
-					VerbosityDisplay("In Commands() - ERROR: Could not detect numerical value in string-based number argument.\n");
+					VerbosityDisplay("In commands::Commands1To10() - ERROR: Could not detect numerical value in string-based number argument.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's a number and try again.\nType \"settings -h\" for more info.\n");
 				}
 				return true;
 			}
 			else if (sStringOptionCommandArgs[0] == "titleback") {
 				if (isNumberi(sStringDataCommandArgs[0])) {
+					// Check if colour number is beyond limits - alert user if so
+					if (std::stoi(sStringDataCommandArgs[0]) < 1 || std::stoi(sStringDataCommandArgs[0]) > 16) {
+						VerbosityDisplay("In commands::Commands1To10() - ERROR: The colour number specified is beyond the acceptable colour number range (1 <= x <= 16).");
+						UserErrorDisplay("ERROR - The specified colour number argument is less than 1 or above 16. Please ensure that the argument is within the acceptable range, and try again later.\n");
+						return true;
+					}
+
 					TitleColourSettings(2, std::stoi(sStringDataCommandArgs[0]));
 				}
 				else {
-					VerbosityDisplay("In Commands() - ERROR: Could not detect numerical value in string-based number argument.\n");
+					VerbosityDisplay("In commands::Commands1To10() - ERROR: Could not detect numerical value in string-based number argument.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's a number and try again.\nType \"settings -h\" for more info.\n");
 				}
 				return true;
 			}
 			else if (sStringOptionCommandArgs[0] == "subheadingfore") {
 				if (isNumberi(sStringDataCommandArgs[0])) {
+					// Check if colour number is beyond limits - alert user if so
+					if (std::stoi(sStringDataCommandArgs[0]) < 1 || std::stoi(sStringDataCommandArgs[0]) > 16) {
+						VerbosityDisplay("In commands::Commands1To10() - ERROR: The colour number specified is beyond the acceptable colour number range (1 <= x <= 16).");
+						UserErrorDisplay("ERROR - The specified colour number argument is less than 1 or above 16. Please ensure that the argument is within the acceptable range, and try again later.\n");
+						return true;
+					}
+
 					SubheadingColourSettings(1, std::stoi(sStringDataCommandArgs[0]));
 				}
 				else {
-					VerbosityDisplay("In Commands() - ERROR: Could not detect numerical value in string-based number argument.\n");
+					VerbosityDisplay("In commands::Commands1To10() - ERROR: Could not detect numerical value in string-based number argument.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's a number and try again.\nType \"settings -h\" for more info.\n");
 				}
 				return true;
 			}
 			else if (sStringOptionCommandArgs[0] == "subheadingback") {
 				if (isNumberi(sStringDataCommandArgs[0])) {
+					// Check if colour number is beyond limits - alert user if so
+					if (std::stoi(sStringDataCommandArgs[0]) < 1 || std::stoi(sStringDataCommandArgs[0]) > 16) {
+						VerbosityDisplay("In commands::Commands1To10() - ERROR: The colour number specified is beyond the acceptable colour number range (1 <= x <= 16).");
+						UserErrorDisplay("ERROR - The specified colour number argument is less than 1 or above 16. Please ensure that the argument is within the acceptable range, and try again later.\n");
+						return true;
+					}
+
 					SubheadingColourSettings(2, std::stoi(sStringDataCommandArgs[0]));
 				}
 				else {
-					VerbosityDisplay("In Commands() - ERROR: Could not detect numerical value in string-based number argument.\n");
+					VerbosityDisplay("In commands::Commands1To10() - ERROR: Could not detect numerical value in string-based number argument.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's a number and try again.\nType \"settings -h\" for more info.\n");
 				}
 
@@ -520,7 +570,7 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 					VerboseMessagesSettings(2);
 				}
 				else {
-					VerbosityDisplay("ERROR: In Commands() - Could not detect correct t/f or true/false value in argument string.\n");
+					VerbosityDisplay("ERROR: In commands::Commands1To10() - Could not detect correct t/f or true/false value in argument string.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's \"t\" or \"f\" and try again.\nType \"settings -h\" for more info.\n");
 				}
 
@@ -534,7 +584,7 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 					DirectionMessagesSettings(2);
 				}
 				else {
-					VerbosityDisplay("ERROR: In Commands() - Could not detect correct t/f or true/false value in argument string.\n");
+					VerbosityDisplay("ERROR: In commands::Commands1To10() - Could not detect correct t/f or true/false value in argument string.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's \"t\" or \"f\" and try again.\nType \"settings -h\" for more info.\n");
 				}
 
@@ -548,7 +598,7 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 					AnsiSettings(2);
 				}
 				else {
-					VerbosityDisplay("ERROR: In Commands() - Could not detect correct t/f or true/false value in argument string.\n");
+					VerbosityDisplay("ERROR: In commands::Commands1To10() - Could not detect correct t/f or true/false value in argument string.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's \"t\" or \"f\" and try again.\nType \"settings -h\" for more info.\n");
 				}
 
@@ -562,7 +612,7 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 					WordWrapSettings(2);
 				}
 				else {
-					VerbosityDisplay("ERROR: In Commands() - Could not detect correct t/f or true/false value in argument string.\n");
+					VerbosityDisplay("ERROR: In commands::Commands1To10() - Could not detect correct t/f or true/false value in argument string.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's \"t\" or \"f\" and try again.\nType \"settings -h\" for more info.\n");
 				}
 
@@ -576,7 +626,7 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 					CursorSettings(1, 2);
 				}
 				else {
-					VerbosityDisplay("ERROR: In Commands() - Could not detect correct t/f or true/false value in argument string.\n");
+					VerbosityDisplay("ERROR: In commands::Commands1To10() - Could not detect correct t/f or true/false value in argument string.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's \"t\" or \"f\" and try again.\nType \"settings -h\" for more info.\n");
 				}
 
@@ -590,7 +640,7 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 					CursorSettings(2, 0, 2);
 				}
 				else {
-					VerbosityDisplay("ERROR: In Commands() - Could not detect correct t/f or true/false value in argument string.\n");
+					VerbosityDisplay("ERROR: In commands::Commands1To10() - Could not detect correct t/f or true/false value in argument string.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's \"t\" or \"f\" and try again.\nType \"settings -h\" for more info.\n");
 				}
 
@@ -607,7 +657,7 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 					CursorSettings(3, 0, 0, 3);
 				}
 				else {
-					VerbosityDisplay("ERROR: In Commands() - Could not detect correct 'block', 'underline' or 'bar' value in argument string.\n");
+					VerbosityDisplay("ERROR: In commands::Commands1To10() - Could not detect correct 'block', 'underline' or 'bar' value in argument string.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's either 'block', 'underline', or 'bar'. Type \"settings -h\" for more info.\n");
 				}
 
@@ -618,7 +668,7 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 					OtherSettings(1, std::stoll(sStringDataCommandArgs[0]), true);
 				}
 				else {
-					VerbosityDisplay("In Commands() - ERROR: Could not detect numerical value in string-based number argument.\n");
+					VerbosityDisplay("In commands::Commands1To10() - ERROR: Could not detect numerical value in string-based number argument.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's a number and try again.\nType \"settings -h\" for more info.\n");
 				}
 
@@ -632,7 +682,7 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 					OtherSettings(2, 0, true, 2);
 				}
 				else {
-					VerbosityDisplay("ERROR: In Commands() - Could not detect correct t/f or true/false value in argument string.\n");
+					VerbosityDisplay("ERROR: In commands::Commands1To10() - Could not detect correct t/f or true/false value in argument string.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's \"t\" or \"f\" and try again.\nType \"settings -h\" for more info.\n");
 				}
 
@@ -646,7 +696,7 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 					OtherSettings(3, 0, true, 0, 2);
 				}
 				else {
-					VerbosityDisplay("ERROR: In Commands() - Could not detect correct t/f or true/false value in argument string.\n");
+					VerbosityDisplay("ERROR: In commands::Commands1To10() - Could not detect correct t/f or true/false value in argument string.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's \"t\" or \"f\" and try again.\nType \"settings -h\" for more info.\n");
 				}
 
@@ -660,7 +710,7 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 					OtherSettings(4, 0, true, 0, 0, 2);
 				}
 				else {
-					VerbosityDisplay("ERROR: In Commands() - Could not detect correct t/f or true/false value in argument string.\n");
+					VerbosityDisplay("ERROR: In commands::Commands1To10() - Could not detect correct t/f or true/false value in argument string.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's \"t\" or \"f\" and try again.\nType \"settings -h\" for more info.\n");
 				}
 
@@ -671,7 +721,7 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 					OtherSettings(5, 0, true, 0, 0, 0, sStringDataCommandArgs[0]);
 				}
 				else {
-					VerbosityDisplay("ERROR: In Commands() - Could not detect any argument string after option.\n");
+					VerbosityDisplay("ERROR: In commands::Commands1To10() - Could not detect any argument string after option.\n");
 					UserErrorDisplay("An error occured. It seems like no option was found. Check your syntax, make sure an option is present and try again. Type \"settings -h\" for more info.\n");
 				}
 
@@ -685,7 +735,7 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 					LogFileSystemSettings(1, 2);
 				}
 				else {
-					VerbosityDisplay("ERROR: In Commands() - Could not detect correct t/f or true/false value in argument string.\n");
+					VerbosityDisplay("ERROR: In commands::Commands1To10() - Could not detect correct t/f or true/false value in argument string.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's \"t\" or \"f\" and try again.\nType \"settings -h\" for more info.\n");
 				}
 
@@ -699,7 +749,7 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 					LogFileSystemSettings(2, 0, 2);
 				}
 				else {
-					VerbosityDisplay("ERROR: In Commands() - Could not detect correct t/f or true/false value in argument string.\n");
+					VerbosityDisplay("ERROR: In commands::Commands1To10() - Could not detect correct t/f or true/false value in argument string.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's \"t\" or \"f\" and try again.\nType \"settings -h\" for more info.\n");
 				}
 
@@ -713,7 +763,7 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 					LogFileSystemSettings(3, 0, 0, 2);
 				}
 				else {
-					VerbosityDisplay("ERROR: In Commands() - Could not detect correct t/f or true/false value in argument string.\n");
+					VerbosityDisplay("ERROR: In commands::Commands1To10() - Could not detect correct t/f or true/false value in argument string.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's \"t\" or \"f\" and try again.\nType \"settings -h\" for more info.\n");
 				}
 
@@ -727,7 +777,7 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 					LogFileSystemSettings(4, 0, 0, 0, 2);
 				}
 				else {
-					VerbosityDisplay("ERROR: In Commands() - Could not detect correct t/f or true/false value in argument string.\n");
+					VerbosityDisplay("ERROR: In commands::Commands1To10() - Could not detect correct t/f or true/false value in argument string.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's \"t\" or \"f\" and try again.\nType \"settings -h\" for more info.\n");
 				}
 
@@ -741,7 +791,7 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 					LogFileSystemSettings(5, 0, 0, 0, 0, 2);
 				}
 				else {
-					VerbosityDisplay("ERROR: In Commands() - Could not detect correct t/f or true/false value in argument string.\n");
+					VerbosityDisplay("ERROR: In commands::Commands1To10() - Could not detect correct t/f or true/false value in argument string.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's \"t\" or \"f\" and try again.\nType \"settings -h\" for more info.\n");
 				}
 
@@ -755,7 +805,7 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 					OtherSettings(6, 0, true, 0, 0, 0, "", 2);
 				}
 				else {
-					VerbosityDisplay("ERROR: In Commands() - Could not detect correct t/f or true/false value in argument string.\n");
+					VerbosityDisplay("ERROR: In commands::Commands1To10() - Could not detect correct t/f or true/false value in argument string.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's \"t\" or \"f\" and try again.\nType \"settings -h\" for more info.\n");
 				}
 
@@ -766,7 +816,7 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 					CarDodgeGameSettings(1, std::stoi(sStringDataCommandArgs[0]), 0, 0, 0);
 				}
 				else {
-					VerbosityDisplay("In Commands() - ERROR: Could not detect numerical value in string-based number argument.\n");
+					VerbosityDisplay("In commands::Commands1To10() - ERROR: Could not detect numerical value in string-based number argument.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's a number and try again.\nType \"settings -h\" for more info.\n");
 				}
 
@@ -792,7 +842,7 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 					CarDodgeGameSettings(2, 0, 6, 0, 0);
 				}
 				else {
-					VerbosityDisplay("ERROR: In Commands() - Could not detect correct 'kartcar', 'thehoverrocket', 'thesweeper', 'theslicer', 'gtspeed' or 'xtraaero' value in argument string.\n");
+					VerbosityDisplay("ERROR: In commands::Commands1To10() - Could not detect correct 'kartcar', 'thehoverrocket', 'thesweeper', 'theslicer', 'gtspeed' or 'xtraaero' value in argument string.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's either: 'kartcar', 'thehoverrocket', 'thesweeper', 'theslicer', 'gtspeed' or 'xtraaero'. Type \"settings -h\" for more info.\n");
 				}
 
@@ -800,10 +850,18 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 			}
 			else if (sStringOptionCommandArgs[0] == "cdforeground") {
 				if (isNumberi(sStringDataCommandArgs[0])) {
+					// Check if colour number is beyond limits - alert user if so
+					if (std::stoi(sStringDataCommandArgs[0]) < 1 || std::stoi(sStringDataCommandArgs[0]) > 16) {
+						VerbosityDisplay("In commands::Commands1To10() - ERROR: The colour number specified is beyond the acceptable colour number range (1 <= x <= 16).");
+						UserErrorDisplay("ERROR - The specified colour number argument is less than 1 or above 16. Please ensure that the argument is within the acceptable range, and try again later.\n");
+						return true;
+
+					}
+
 					CarDodgeGameSettings(3, 0, 0, std::stoi(sStringDataCommandArgs[0]), 0);
 				}
 				else {
-					VerbosityDisplay("In Commands() - ERROR: Could not detect numerical value in string-based number argument.\n");
+					VerbosityDisplay("In commands::Commands1To10() - ERROR: Could not detect numerical value in string-based number argument.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's a number and try again.\nType \"settings -h\" for more info.\n");
 				}
 
@@ -811,10 +869,17 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 			}
 			else if (sStringOptionCommandArgs[0] == "cdbackground") {
 				if (isNumberi(sStringDataCommandArgs[0])) {
+					// Check if colour number is beyond limits - alert user if so
+					if (std::stoi(sStringDataCommandArgs[0]) < 1 || std::stoi(sStringDataCommandArgs[0]) > 16) {
+						VerbosityDisplay("In commands::Commands1To10() - ERROR: The colour number specified is beyond the acceptable colour number range (1 <= x <= 16).");
+						UserErrorDisplay("ERROR - The specified colour number argument is less than 1 or above 16. Please ensure that the argument is within the acceptable range, and try again later.\n");
+						return true;
+					}
+
 					CarDodgeGameSettings(4, 0, 0, 0, std::stoi(sStringDataCommandArgs[0]));
 				}
 				else {
-					VerbosityDisplay("In Commands() - ERROR: Could not detect numerical value in string-based number argument.\n");
+					VerbosityDisplay("In commands::Commands1To10() - ERROR: Could not detect numerical value in string-based number argument.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's a number and try again.\nType \"settings -h\" for more info.\n");
 				}
 
@@ -822,10 +887,17 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 			}
 			else if (sStringOptionCommandArgs[0] == "gtnforeground") {
 				if (isNumberi(sStringDataCommandArgs[0])) {
+					// Check if colour number is beyond limits - alert user if so
+					if (std::stoi(sStringDataCommandArgs[0]) < 1 || std::stoi(sStringDataCommandArgs[0]) > 16) {
+						VerbosityDisplay("In commands::Commands1To10() - ERROR: The colour number specified is beyond the acceptable colour number range (1 <= x <= 16).");
+						UserErrorDisplay("ERROR - The specified colour number argument is less than 1 or above 16. Please ensure that the argument is within the acceptable range, and try again later.\n");
+						return true;
+					}
+
 					GuessTheNumberGameSettings(1, std::stoi(sStringDataCommandArgs[0]), 0);
 				}
 				else {
-					VerbosityDisplay("In Commands() - ERROR: Could not detect numerical value in string-based number argument.\n");
+					VerbosityDisplay("In commands::Commands1To10() - ERROR: Could not detect numerical value in string-based number argument.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's a number and try again.\nType \"settings -h\" for more info.\n");
 				}
 
@@ -833,10 +905,17 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 			}
 			else if (sStringOptionCommandArgs[0] == "gtnbackground") {
 				if (isNumberi(sStringDataCommandArgs[0])) {
+					// Check if colour number is beyond limits - alert user if so
+					if (std::stoi(sStringDataCommandArgs[0]) < 1 || std::stoi(sStringDataCommandArgs[0]) > 16) {
+						VerbosityDisplay("In commands::Commands1To10() - ERROR: The colour number specified is beyond the acceptable colour number range (1 <= x <= 16).");
+						UserErrorDisplay("ERROR - The specified colour number argument is less than 1 or above 16. Please ensure that the argument is within the acceptable range, and try again later.\n");
+						return true;
+					}
+
 					GuessTheNumberGameSettings(2, 0, std::stoi(sStringDataCommandArgs[0]));
 				}
 				else {
-					VerbosityDisplay("In Commands() - ERROR: Could not detect numerical value in string-based number argument.\n");
+					VerbosityDisplay("In commands::Commands1To10() - ERROR: Could not detect numerical value in string-based number argument.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's a number and try again.\nType \"settings -h\" for more info.\n");
 				}
 
@@ -844,10 +923,17 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 			}
 			else if (sStringOptionCommandArgs[0] == "gtneforeground") {
 				if (isNumberi(sStringDataCommandArgs[0])) {
+					// Check if colour number is beyond limits - alert user if so
+					if (std::stoi(sStringDataCommandArgs[0]) < 1 || std::stoi(sStringDataCommandArgs[0]) > 16) {
+						VerbosityDisplay("In commands::Commands1To10() - ERROR: The colour number specified is beyond the acceptable colour number range (1 <= x <= 16).");
+						UserErrorDisplay("ERROR - The specified colour number argument is less than 1 or above 16. Please ensure that the argument is within the acceptable range, and try again later.\n");
+						return true;
+					}
+
 					GuessTheNumberExtremeGameSettings(1, std::stoi(sStringDataCommandArgs[0]), 0);
 				}
 				else {
-					VerbosityDisplay("In Commands() - ERROR: Could not detect numerical value in string-based number argument.\n");
+					VerbosityDisplay("In commands::Commands1To10() - ERROR: Could not detect numerical value in string-based number argument.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's a number and try again.\nType \"settings -h\" for more info.\n");
 				}
 
@@ -855,10 +941,17 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 			}
 			else if (sStringOptionCommandArgs[0] == "gtnebackground") {
 				if (isNumberi(sStringDataCommandArgs[0])) {
+					// Check if colour number is beyond limits - alert user if so
+					if (std::stoi(sStringDataCommandArgs[0]) < 1 || std::stoi(sStringDataCommandArgs[0]) > 16) {
+						VerbosityDisplay("In commands::Commands1To10() - ERROR: The colour number specified is beyond the acceptable colour number range (1 <= x <= 16).");
+						UserErrorDisplay("ERROR - The specified colour number argument is less than 1 or above 16. Please ensure that the argument is within the acceptable range, and try again later.\n");
+						return true;
+					}
+
 					GuessTheNumberExtremeGameSettings(2, 0, std::stoi(sStringDataCommandArgs[0]));
 				}
 				else {
-					VerbosityDisplay("In Commands() - ERROR: Could not detect numerical value in string-based number argument.\n");
+					VerbosityDisplay("In commands::Commands1To10() - ERROR: Could not detect numerical value in string-based number argument.\n");
 					UserErrorDisplay("An error occured. Your setting option seems to be incorrect. Make sure it's a number and try again.\nType \"settings -h\" for more info.\n");
 				}
 
@@ -935,7 +1028,7 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 				break;
 
 			default:
-				VerbosityDisplay("In Commands() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
+				VerbosityDisplay("In commands::Commands1To10() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
 				UserErrorDisplay("ERROR - Unknown error occured. Please try again later.\n");
 				return true;
 			}
@@ -965,7 +1058,7 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 			std::cout << "\n";
 
 			// Take title input
-			sTitle = StrInput("Please input your desired title (254 characters max): > ");
+			sTitle = StrInput("Please input your desired title (65535 characters max): > ");
 		}
 
 		// Set the window title
@@ -976,7 +1069,7 @@ bool commands::Commands1To10(const std::string sCommand, char* cCommandArgs, con
 		}
 		else {
 			// Failed - too long of a string
-			UserErrorDisplay("Setting console window title failed!\nPlease check if your title is too long. It cannot be longer than 254 characters.\n");
+			UserErrorDisplay("Setting console window title failed!\nPlease check if your title is too long. It cannot be longer than 65535 characters.\n");
 		}
 
 		return true;

--- a/CommandFiles/CommandsFiles/CommandsFile_21to30.cpp
+++ b/CommandFiles/CommandsFiles/CommandsFile_21to30.cpp
@@ -31,7 +31,7 @@ bool commands::Commands21To30(const std::string sCommand, char* cCommandArgs, co
 			if (sStringDataCommandArgs[0] != "") {
 				if (sStringDataCommandArgs[1] == "") {
 					// Error message
-					VerbosityDisplay("In Commands() - ERROR: Vital argument not found.\n");
+					VerbosityDisplay("In commands::Commands21To30() - ERROR: Vital argument not found.\n");
 					UserErrorDisplay("ERROR: You need to have both the file location AND destination file directories included in your arguments.\nSee \"copy -h\" for more info.\n");
 
 					return true;
@@ -113,7 +113,7 @@ bool commands::Commands21To30(const std::string sCommand, char* cCommandArgs, co
 		
 		// Catch bad memory allocation to avoid exception
 		catch (const std::bad_alloc&) {
-			VerbosityDisplay("In Commands(): ERROR - Memory allocation failed when copying using std::filesystem::copy (std::bad_alloc).\n");
+			VerbosityDisplay("In commands::Commands21To30(): ERROR - Memory allocation failed when copying using std::filesystem::copy (std::bad_alloc).\n");
 			UserErrorDisplay("ERROR - Failed to allocate memory before copy operation. Please try again later.\n");
 
 			return true;
@@ -122,28 +122,28 @@ bool commands::Commands21To30(const std::string sCommand, char* cCommandArgs, co
 		// Error codes output
 		if (ecTestZone.value() != 0) {
 			if (ecTestZone == std::errc::file_exists) {
-				VerbosityDisplay("In Commands(): ERROR - File exists in the destination location already. -o flag not specified, so copy failed. STDC++ error details: " + ecTestZone.message() + " (std::errc::file_exists).\n");
+				VerbosityDisplay("In commands::Commands21To30(): ERROR - File exists in the destination location already. -o flag not specified, so copy failed. STDC++ error details: " + ecTestZone.message() + " (std::errc::file_exists).\n");
 				UserErrorDisplay("Sorry, but the file exists in the copy location already. Please try again later.\n");
 			}
 			else if (ecTestZone == std::errc::permission_denied) {
-				VerbosityDisplay("In Commands(): ERROR - No sufficient permissions available for file access. STDC++ error details: " + ecTestZone.message() + " (std::errc::permission_denied).\n");
+				VerbosityDisplay("In commands::Commands21To30(): ERROR - No sufficient permissions available for file access. STDC++ error details: " + ecTestZone.message() + " (std::errc::permission_denied).\n");
 				UserErrorDisplay("Sorry, but there aren't any sufficient permissions to access the file. Please try again with elevated permissions.\n");
 			}
 			else if (ecTestZone == std::errc::is_a_directory) {
-				VerbosityDisplay("In Commands(): ERROR - Source argument is a directory, and -d flag not specified, so copy failed. STDC++ error details: " + ecTestZone.message() + " (std::errc::is_a_directory).\n");
+				VerbosityDisplay("In commands::Commands21To30(): ERROR - Source argument is a directory, and -d flag not specified, so copy failed. STDC++ error details: " + ecTestZone.message() + " (std::errc::is_a_directory).\n");
 				UserErrorDisplay("Sorry, but the specified source argument is a directory, not a file.\nIf you want to copy the contents of a directory, use the -d argument.\nPlease try again later.\n");
 			}
 			else if (ecTestZone == std::errc::io_error) {
-				VerbosityDisplay("In Commands(): ERROR - Unknown I/O error occured when copying. STDC++ error details: " + ecTestZone.message() + " (std::errc::io_error).\n");
+				VerbosityDisplay("In commands::Commands21To30(): ERROR - Unknown I/O error occured when copying. STDC++ error details: " + ecTestZone.message() + " (std::errc::io_error).\n");
 				UserErrorDisplay("Sorry, but an unknown I/O error occured when copying.\nThis could possibly relate to losing access to the source file or destination directory, or even a hardware error.\nPlease try again later.\n");
 			}
 			else if (ecTestZone == std::errc::no_such_file_or_directory) {
-				VerbosityDisplay("In Commands(): ERROR - No such file or directory exists in either the source or destination argument paths. STDC++ error details: " + ecTestZone.message() + " (std::errc::no_such_file_or_directory).\n");
+				VerbosityDisplay("In commands::Commands21To30(): ERROR - No such file or directory exists in either the source or destination argument paths. STDC++ error details: " + ecTestZone.message() + " (std::errc::no_such_file_or_directory).\n");
 				UserErrorDisplay("Sorry, but the specified source filepath or destination directory path does not exist.\nPlease check the specified arguments and try again later.\n");
 			}
 			else {
 				// Unknown error
-				VerbosityDisplay("In Commands(): ERROR - Unknown error when copying file. STDC++ error details: " + ecTestZone.message() + " (Error Code " + std::to_string(ecTestZone.value()) + ").\n");
+				VerbosityDisplay("In commands::Commands21To30(): ERROR - Unknown error when copying file. STDC++ error details: " + ecTestZone.message() + " (Error Code " + std::to_string(ecTestZone.value()) + ").\n");
 				UserErrorDisplay("Sorry, but an unknown error of code " + std::to_string(ecTestZone.value()) + " occured when copying. Please try again later.\n");
 			}
 		}
@@ -176,7 +176,7 @@ bool commands::Commands21To30(const std::string sCommand, char* cCommandArgs, co
 				}
 				else {
 					// Error message
-					VerbosityDisplay("In Commands() - ERROR: Vital argument not found.\n");
+					VerbosityDisplay("In commands::Commands21To30() - ERROR: Vital argument not found.\n");
 					UserErrorDisplay("ERROR: You need to have both the file location AND destination file directories included in your arguments.\nSee \"copyfile -h\" for more info.\n");
 					
 					return true;
@@ -250,8 +250,8 @@ bool commands::Commands21To30(const std::string sCommand, char* cCommandArgs, co
 		VerbosityDisplay("Copying file " + sOriginalFilePath + " to " + sDestinationFilePath + "...");
 		std::cout << "Copying file...\n";
 		if (!CopyFileA(sOriginalFilePath.c_str(), sDestinationFilePath.c_str(), false)) {
-			VerbosityDisplay("In Commands() - ERROR: Existing file when copying to file directory detected. File copy operation has failed. GetLastError() error code: " + std::to_string(GetLastError()) + "\n");
-			UserErrorDisplay("An error occured while copying the file.\nPossibly the original file is nonexistent?\n");
+			VerbosityDisplay("In commands::Commands21To30() - ERROR: Existing file when copying to file directory possible. File copy operation has failed. GetLastError() error code: " + std::to_string(GetLastError()) + "\n");
+			UserErrorDisplay("An error occured while copying the file.\nPossibly the original file is nonexistent, not enough memory, lack of permissions or invalid destination file?\n");
 		}
 		else {
 			colour(LGRN, ConfigObjMain.sColourGlobalBack);
@@ -460,7 +460,7 @@ bool commands::Commands21To30(const std::string sCommand, char* cCommandArgs, co
 			return true;
 
 		default:
-			VerbosityDisplay("In Commands() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
+			VerbosityDisplay("In commands::Commands21To30() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
 			UserErrorDisplay("ERROR - Unknown error occured. Please try again later.\n");
 			break;
 		}
@@ -595,7 +595,7 @@ bool commands::Commands21To30(const std::string sCommand, char* cCommandArgs, co
 			Exiting();
 			return true;
 		default:
-			VerbosityDisplay("In Commands() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
+			VerbosityDisplay("In commands::Commands21To30() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
 			UserErrorDisplay("ERROR - Unknown error occured. Please try again later.\n");
 			Exiting();
 			return true;
@@ -633,14 +633,15 @@ bool commands::Commands21To30(const std::string sCommand, char* cCommandArgs, co
 				helpmsgs::ShellExecuteHelp();
 				return true;
 			}
-			else if (sStringDataCommandArgs[0] != "") {
-				sCommandText = sStringDataCommandArgs[0];
+			
+			if (sStringDataCommandArgs[i] != "") {
+				sCommandText = sStringDataCommandArgs[i];
 			}
 		}
 
 		// User Interface
 		if (sCommandText == "") {
-			CentreColouredText("___SHELLEXECUTE___", 1);
+			CentreColouredText(" ___SHELLEXECUTE___ ", 1);
 			std::cout << "\n\n";
 
 			sCommandText = StrInput("Please input your desired CMD command to run (0 to exit): > ");
@@ -658,7 +659,7 @@ bool commands::Commands21To30(const std::string sCommand, char* cCommandArgs, co
 		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 
 		// Execute command
-		system(sStringDataCommandArgs[0].c_str());
+		system(sCommandText.c_str());
 
 		colour(LGRN, ConfigObjMain.sColourGlobalBack);
 		std::cout << "\nCommand execution successful!\n";
@@ -699,7 +700,7 @@ bool commands::Commands21To30(const std::string sCommand, char* cCommandArgs, co
 				if (sStringDataCommandArgs[i] != "")
 				{
 					if (isNumberull(sStringDataCommandArgs[i]) == false) {
-						VerbosityDisplay("In Commands() - ERROR: Could not detect numerical value in string-based number argument.\n");
+						VerbosityDisplay("In commands::Commands21To30() - ERROR: Could not detect numerical value in string-based number argument.\n");
 						UserErrorDisplay("ERROR: The speed argument given is not a number.\nPlease try again later, or see 'hacker -h' for more details.\n");
 						return true;
 					}
@@ -712,13 +713,13 @@ bool commands::Commands21To30(const std::string sCommand, char* cCommandArgs, co
 				sFileName = sStringDataCommandArgs[i];
 
 				// If statements for safety
-				if (i + 1 < 128) {
+				if (i + 1 < nArgArraySize) {
 					// Firstly, validate string to be a number
 					// Don't check empty strings
 					if (sStringDataCommandArgs[i + 1] != "") 
 					{
 						if (isNumberull(sStringDataCommandArgs[i + 1]) == false) {
-							VerbosityDisplay("In Commands() - ERROR: Could not detect numerical value in string-based number argument.\n");
+							VerbosityDisplay("In commands::Commands21To30() - ERROR: Could not detect numerical value in string-based number argument.\n");
 							UserErrorDisplay("ERROR: The speed argument given is not a number.\nPlease try again later, or see 'hacker -h' for more details.\n");
 							return true;
 						}
@@ -858,7 +859,7 @@ bool commands::Commands21To30(const std::string sCommand, char* cCommandArgs, co
 
 		// Error occured
 		else {
-			VerbosityDisplay("In Commands() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
+			VerbosityDisplay("In commands::Commands21To30() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
 			UserErrorDisplay("ERROR - Unknown error occured. Please try again later.\n");
 		}
 

--- a/CommandFiles/CommandsFiles/CommandsFile_31to40.cpp
+++ b/CommandFiles/CommandsFiles/CommandsFile_31to40.cpp
@@ -189,7 +189,7 @@ bool commands::Commands31To40(const std::string sCommand, char* cCommandArgs, co
 				// Check if argument is a number
 				if (sStringDataCommandArgs[0] != "") {
 					if (isNumberull(sStringDataCommandArgs[0]) == false) {
-						VerbosityDisplay("In Commands() - ERROR: Could not detect numerical value in string-based number argument.\n");
+						VerbosityDisplay("In commands::Commands31To40() - ERROR: Could not detect numerical value in string-based number argument.\n");
 						UserErrorDisplay("ERROR - Passes argument is not a number.\nPlease try again later, or see 'memtest -h' for more details.\n");
 
 						return true;
@@ -205,7 +205,7 @@ bool commands::Commands31To40(const std::string sCommand, char* cCommandArgs, co
 				// Check if argument is a number
 				if (sStringDataCommandArgs[0] != "") {
 					if (isNumberull(sStringDataCommandArgs[0]) == false) {
-						VerbosityDisplay("In Commands() - ERROR: Could not detect numerical value in string-based number argument.\n");
+						VerbosityDisplay("In commands::Commands31To40() - ERROR: Could not detect numerical value in string-based number argument.\n");
 						UserErrorDisplay("ERROR - Passes argument is not a number.\nPlease try again later, or see 'memtest -h' for more details.\n");
 
 						return true;
@@ -220,7 +220,7 @@ bool commands::Commands31To40(const std::string sCommand, char* cCommandArgs, co
 				// Check if argument is a number
 				if (sStringDataCommandArgs[0] != "") {
 					if (isNumberull(sStringDataCommandArgs[0]) == false) {
-						VerbosityDisplay("In Commands() - ERROR: Could not detect numerical value in string-based number argument.\n");
+						VerbosityDisplay("In commands::Commands31To40() - ERROR: Could not detect numerical value in string-based number argument.\n");
 						UserErrorDisplay("ERROR - Passes argument is not a number.\nPlease try again later, or see 'memtest -h' for more details.\n");
 
 						return true;
@@ -404,7 +404,7 @@ bool commands::Commands31To40(const std::string sCommand, char* cCommandArgs, co
 
 		// Failed, unknown return value
 		else {
-			VerbosityDisplay("In Commands() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
+			VerbosityDisplay("In commands::Commands31To40() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
 			UserErrorDisplay("ERROR: An unknown error occured. Please try again later.\n");
 
 			return true;

--- a/CommandFiles/CommandsFiles/CommandsFile_41to50.cpp
+++ b/CommandFiles/CommandsFiles/CommandsFile_41to50.cpp
@@ -26,7 +26,7 @@ bool commands::Commands41To50(const std::string sCommand, char* cCommandArgs, co
 					sNotesText = sStringDataCommandArgs[0];
 				}
 				else {
-					VerbosityDisplay("ERROR: In Commands() - Vital argument not found.\n");
+					VerbosityDisplay("ERROR: In commands::Commands41To50() - Vital argument not found.\n");
 					UserErrorDisplay("ERROR - No form of note text argument found.\nPlease make sure that's there, and try again.\nSee \"notes -h\" for more info.\n");
 
 					return true;
@@ -40,7 +40,7 @@ bool commands::Commands41To50(const std::string sCommand, char* cCommandArgs, co
 						nNotesLine = std::stoull(sStringDataCommandArgs[0]) - 1;
 						if (nNotesLine > NotesMain.GetCurrentNotesCount() - 1) {
 							// Line number too large
-							VerbosityDisplay("In Commands() - ERROR: String-based number argument is too large/small in correlation to number of notes currently in notes array.\n");
+							VerbosityDisplay("In commands::Commands41To50() - ERROR: String-based number argument is too large/small in correlation to number of notes currently in notes array.\n");
 							UserErrorDisplay("ERROR - Line number is too large/small, and is accessing a nonexistent note line. Please change the argument, and try again.\nSee \"notes -h\" for more info.\n");
 
 							return true;
@@ -48,7 +48,7 @@ bool commands::Commands41To50(const std::string sCommand, char* cCommandArgs, co
 					}
 					else {
 						// Not a number or it is negative
-						VerbosityDisplay("In Commands() - ERROR: Could not detect numerical value in string-based number argument, or argument was negative.\n");
+						VerbosityDisplay("In commands::Commands41To50() - ERROR: Could not detect numerical value in string-based number argument, or argument was negative.\n");
 						UserErrorDisplay("ERROR - Line number is not a number, or it is negative. Please change the argument, and try again.\nSee \"notes -h\" for more info.\n");
 
 						return true;
@@ -69,7 +69,7 @@ bool commands::Commands41To50(const std::string sCommand, char* cCommandArgs, co
 					}
 					else {
 						// Not a number or it is negative
-						VerbosityDisplay("In Commands() - ERROR: Could not detect numerical value in string-based number argument, or argument was negative.\n");
+						VerbosityDisplay("In commands::Commands41To50() - ERROR: Could not detect numerical value in string-based number argument, or argument was negative.\n");
 						UserErrorDisplay("ERROR - Line number is not a number, or it is negative. Please change the argument, and try again.\nSee \"notes -h\" for more info.\n");
 
 						return true;
@@ -85,7 +85,7 @@ bool commands::Commands41To50(const std::string sCommand, char* cCommandArgs, co
 					sNotesText = sStringDataCommandArgs[1];
 				}
 				else {
-					VerbosityDisplay("ERROR: In Commands() - Vital argument not found.\n");
+					VerbosityDisplay("ERROR: In commands::Commands41To50() - Vital argument not found.\n");
 					UserErrorDisplay("ERROR - No form of note text argument found.\nPlease make sure that's there, and try again.\nSee \"notes -h\" for more info.\n");
 
 					return true;
@@ -144,7 +144,7 @@ bool commands::Commands41To50(const std::string sCommand, char* cCommandArgs, co
 					colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 				}
 				else {
-					VerbosityDisplay("In Commands() - ERROR: Failed to write to notes file and save notes.\n");
+					VerbosityDisplay("In commands::Commands41To50() - ERROR: Failed to write to notes file and save notes.\n");
 					UserErrorDisplay("ERROR - Failed to save new added notes. Exiting anyway...\n");
 
 					return true;
@@ -174,7 +174,7 @@ bool commands::Commands41To50(const std::string sCommand, char* cCommandArgs, co
 					colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 				}
 				else {
-					VerbosityDisplay("In Commands() - ERROR: Failed to write to notes file and save notes.\n");
+					VerbosityDisplay("In commands::Commands41To50() - ERROR: Failed to write to notes file and save notes.\n");
 					UserErrorDisplay("ERROR - Failed to remove the notes from the notes file. Exiting anyway...\n");
 
 					return true;
@@ -205,7 +205,7 @@ bool commands::Commands41To50(const std::string sCommand, char* cCommandArgs, co
 					colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 				}
 				else {
-					VerbosityDisplay("In Commands() - ERROR: Failed to write to notes file and save notes.\n");
+					VerbosityDisplay("In commands::Commands41To50() - ERROR: Failed to write to notes file and save notes.\n");
 					UserErrorDisplay("ERROR - Failed to save modified notes. Exiting anyway...\n");
 
 					return true;
@@ -305,7 +305,7 @@ bool commands::Commands41To50(const std::string sCommand, char* cCommandArgs, co
 
 		// Error
 		else {
-			VerbosityDisplay("In Commands() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
+			VerbosityDisplay("In commands::Commands41To50() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
 			UserErrorDisplay("ERROR - Unknown error occured. Please try again later.\n");
 
 			return true;
@@ -350,7 +350,7 @@ bool commands::Commands41To50(const std::string sCommand, char* cCommandArgs, co
 			slowcharfn(true, "Welcome to FileParse!");
 			colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 
-			std::cout << "This is where you can run scripts on ZeeTerminal, where commands can be automatically executed.\n\n";
+			std::cout << wordWrap("This is where you can run scripts on ZeeTerminal, where commands can be automatically executed.\n\n");
 
 			sFilePath = StrInput("Please input filepath for custom script (0 to exit, '*open' to open file dialogue): > ");
 
@@ -377,7 +377,7 @@ bool commands::Commands41To50(const std::string sCommand, char* cCommandArgs, co
 
 		// Initialise FileParse system
 		if (!fparse::InitialiseFileParse(sFilePath, bExitOnCompletion)) {
-			UserErrorDisplay("ERROR - An error occured while initialising the FileParse System. Possibly a nonexistent file path?\n");
+			UserErrorDisplay("ERROR - An error occured while initialising the FileParse System. Possibly a nonexistent file path, lack of permissions or out of memory? Please try again later.\n");
 			return true;
 		}
 		else {
@@ -447,7 +447,7 @@ bool commands::Commands41To50(const std::string sCommand, char* cCommandArgs, co
 			}
 			else {
 				// Unknown error
-				VerbosityDisplay("In Commands() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
+				VerbosityDisplay("In commands::Commands41To50() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
 				UserErrorDisplay("ERROR - Unknown error occured. Please try again later.\n");
 				return true;
 			}
@@ -703,7 +703,7 @@ bool commands::Commands41To50(const std::string sCommand, char* cCommandArgs, co
 			}
 			else if (sStringOptionCommandArgs[i] == "saytext") {
 				if (sStringDataCommandArgs[i] == "") {
-					VerbosityDisplay("ERROR: In Commands() - Could not detect any argument string after option.\n");
+					VerbosityDisplay("ERROR: In commands::Commands41To50() - Could not detect any argument string after option.\n");
 					UserErrorDisplay("ERROR - No text data argument found. Please check for a text argument, and try again.\nType \"cow -h\" for more info.\n");
 					return true;
 				}
@@ -756,7 +756,7 @@ bool commands::Commands41To50(const std::string sCommand, char* cCommandArgs, co
 			return true;
 		}
 		else {
-			VerbosityDisplay("In Commands() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
+			VerbosityDisplay("In commands::Commands41To50() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
 			UserErrorDisplay("ERROR - Unknown error occured. Please try again later.\n");
 		}
 
@@ -787,7 +787,7 @@ bool commands::Commands41To50(const std::string sCommand, char* cCommandArgs, co
 			}
 			else if (sStringOptionCommandArgs[i] == "saytext") {
 				if (sStringDataCommandArgs[i] == "") {
-					VerbosityDisplay("ERROR: In Commands() - Could not detect any argument string after option.\n");
+					VerbosityDisplay("ERROR: In commands::Commands41To50() - Could not detect any argument string after option.\n");
 					UserErrorDisplay("ERROR - No text data argument found. Please check for a text argument, and try again.\nType \"cat -h\" for more info.\n");
 					return true;
 				}
@@ -840,7 +840,7 @@ bool commands::Commands41To50(const std::string sCommand, char* cCommandArgs, co
 			return true;
 		}
 		else {
-			VerbosityDisplay("In Commands() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
+			VerbosityDisplay("In commands::Commands41To50() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
 			UserErrorDisplay("ERROR - Unknown error occured. Please try again later.\n");
 		}
 
@@ -871,7 +871,7 @@ bool commands::Commands41To50(const std::string sCommand, char* cCommandArgs, co
 			}
 			else if (sStringOptionCommandArgs[i] == "saytext") {
 				if (sStringDataCommandArgs[i] == "") {
-					VerbosityDisplay("ERROR: In Commands() - Could not detect any argument string after option.\n");
+					VerbosityDisplay("ERROR: In commands::Commands41To50() - Could not detect any argument string after option.\n");
 					UserErrorDisplay("ERROR - No text data argument found. Please check for a text argument, and try again.\nType \"bunny -h\" for more info.\n");
 					return true;
 				}
@@ -924,7 +924,7 @@ bool commands::Commands41To50(const std::string sCommand, char* cCommandArgs, co
 			return true;
 		}
 		else {
-			VerbosityDisplay("In Commands() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
+			VerbosityDisplay("In commands::Commands41To50() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
 			UserErrorDisplay("ERROR - Unknown error occured. Please try again later.\n");
 		}
 

--- a/CommandFiles/CommandsFiles/CommandsFile_51to60.cpp
+++ b/CommandFiles/CommandsFiles/CommandsFile_51to60.cpp
@@ -83,7 +83,7 @@ bool commands::Commands51To60(const std::string sCommand, char* cCommandArgs, co
 
 			// Error
 			else {
-				VerbosityDisplay("In Commands() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
+				VerbosityDisplay("In commands::Commands51To60() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
 				UserErrorDisplay("ERROR - Unknown error occured. Please try again later.\n");
 			}
 		}
@@ -97,6 +97,8 @@ bool commands::Commands51To60(const std::string sCommand, char* cCommandArgs, co
 		std::string sFileName = "";
 		RYRYKEY rKey1 = 0;
 		RYRYKEY rKey2 = 0;
+		bool bFirstKeyInputtedAsArg = false;
+		bool bSecondKeyInputtedAsArg = false;
 		int nOption = 0; // 0 is reserved, 1 is encrypt, 2 is decrypt
 
 		// Arguments Interface
@@ -145,11 +147,13 @@ bool commands::Commands51To60(const std::string sCommand, char* cCommandArgs, co
 					if (i + 1 < nArgArraySize && sStringDataCommandArgs[i + 1] != "") {
 						if (isNumberull(sStringDataCommandArgs[i + 1])) {
 							rKey1 = std::stoull(sStringDataCommandArgs[i + 1]);
+							bFirstKeyInputtedAsArg = true;
 						}
 					}
 					if (i + 2 < nArgArraySize && sStringDataCommandArgs[i + 2] != "") {
 						if (isNumberull(sStringDataCommandArgs[i + 2])) {
 							rKey2 = std::stoull(sStringDataCommandArgs[i + 2]);
+							bSecondKeyInputtedAsArg = true;
 						}
 					}
 				}
@@ -179,7 +183,7 @@ bool commands::Commands51To60(const std::string sCommand, char* cCommandArgs, co
 			return true;
 		}
 		else if (nOption < -1 || nOption == 0 || nOption > 2) {
-			VerbosityDisplay("In Commands() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
+			VerbosityDisplay("In commands::Commands51To60() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
 			UserErrorDisplay("ERROR - Unknown error occured. Please try again later.\n");
 			return true;
 		}
@@ -222,15 +226,15 @@ bool commands::Commands51To60(const std::string sCommand, char* cCommandArgs, co
 			}
 		}
 
-		if (bUseWindowsEncryption == false && rKey1 == 0) {
+		if (bUseWindowsEncryption == false && !bFirstKeyInputtedAsArg) {
 			std::string sPrompt = "Please input the first key for ";
-			if (nOption == 1) sPrompt += "encryption";
+			if (nOption == 1) sPrompt += "encryption (to unlock data later)";
 			else if (nOption == 2) sPrompt += "decryption";
 			rKey1 = PositiveNumInputull(sPrompt + ": > ");
 		}
-		if (bUseWindowsEncryption == false && rKey2 == 0) {
+		if (bUseWindowsEncryption == false && !bSecondKeyInputtedAsArg) {
 			std::string sPrompt = "Please input the second key for ";
-			if (nOption == 1) sPrompt += "encryption";
+			if (nOption == 1) sPrompt += "encryption (to unlock data later)";
 			else if (nOption == 2) sPrompt += "decryption";
 			rKey2 = PositiveNumInputull(sPrompt + ": > ");
 		}
@@ -239,7 +243,7 @@ bool commands::Commands51To60(const std::string sCommand, char* cCommandArgs, co
 		if (nOption == 1) {
 			if (bUseWindowsEncryption) {
 				if (!EncryptFileA(sFileName.c_str())) {
-					VerbosityDisplay("In Commands(): ERROR - EncryptFileA() function failed, with error code " + std::to_string(GetLastError()) + ".\n");
+					VerbosityDisplay("In commands::Commands51To60(): ERROR - EncryptFileA() function failed, with error code " + std::to_string(GetLastError()) + ".\n");
 					UserErrorDisplay("ERROR - An error occured when encrypting data. Failed with error code " + std::to_string(GetLastError()) + ".\n");
 				}
 				else {
@@ -264,7 +268,6 @@ bool commands::Commands51To60(const std::string sCommand, char* cCommandArgs, co
 							}
 						}
 					}
-
 				}
 				else {
 					if (!FileCryptorObj.EncryptFile(sFileName, rKey1, rKey2)) {
@@ -289,7 +292,7 @@ bool commands::Commands51To60(const std::string sCommand, char* cCommandArgs, co
 		else if (nOption == 2) {
 			if (bUseWindowsEncryption) {
 				if (!DecryptFileA(sFileName.c_str(), NULL)) {
-					VerbosityDisplay("In Commands(): ERROR - DecryptFileA() function failed, with error code " + std::to_string(GetLastError()) + ".\n");
+					VerbosityDisplay("In commands::Commands51To60(): ERROR - DecryptFileA() function failed, with error code " + std::to_string(GetLastError()) + ".\n");
 					UserErrorDisplay("ERROR - An error occured when decrypting data. Failed with error code " + std::to_string(GetLastError()) + ".\n");
 				}
 				else {
@@ -314,7 +317,6 @@ bool commands::Commands51To60(const std::string sCommand, char* cCommandArgs, co
 							}
 						}
 					}
-
 				}
 				else {
 					if (!FileCryptorObj.DecryptFile(sFileName, rKey1, rKey2)) {
@@ -403,20 +405,20 @@ bool commands::Commands51To60(const std::string sCommand, char* cCommandArgs, co
 
 			// 0 means no files have been deleted
 			if (nReturnCode == 0) {
-				VerbosityDisplay("In Commands(): ERROR - Failed to delete file/folder. Error code: 2. Error info: File/folder not found.\n");
+				VerbosityDisplay("In commands::Commands51To60(): ERROR - Failed to delete file/folder. Error code: 2. Error info: File/folder not found.\n");
 				UserErrorDisplay("ERROR - An error occured when deleting file/folder. Error info: File/folder not found.\n");
 				return true;
 			}
 			// -1 means error
 			else if (nReturnCode == -1) {
-				VerbosityDisplay("In Commands(): ERROR - Failed to delete file/folder. Error code: " + std::to_string(ecDelete.value()) + ". Error info: " + ecDelete.message() + ".\n");
+				VerbosityDisplay("In commands::Commands51To60(): ERROR - Failed to delete file/folder. Error code: " + std::to_string(ecDelete.value()) + ". Error info: " + ecDelete.message() + ".\n");
 				UserErrorDisplay("ERROR - An error occured when deleting file/folder. Error code: " + std::to_string(ecDelete.value()) + ".\n");
 				return true;
 			}
 		}
 
 		catch (std::bad_alloc&) {
-			VerbosityDisplay("In Commands(): ERROR - Memory allocation failed for std::filesystem::remove_all().\n");
+			VerbosityDisplay("In commands::Commands51To60(): ERROR - Memory allocation failed for std::filesystem::remove_all().\n");
 			UserErrorDisplay("ERROR - Failed to allocate memory. Please try again later.\n");
 			return true;
 		}
@@ -726,7 +728,7 @@ bool commands::Commands51To60(const std::string sCommand, char* cCommandArgs, co
 			if (sStringDataCommandArgs[i] != "") {
 				// Incorrect argument type
 				if (!isNumberi(sStringDataCommandArgs[i])) {
-					VerbosityDisplay("In CommandsFile51To60() - ERROR: Number argument (in the form of string) is invalid or out of range.\n");
+					VerbosityDisplay("In commands::Commands51To60() - ERROR: Number argument (in the form of string) is invalid or out of range.\n");
 					UserErrorDisplay("ERROR - Your number argument seems to be incorrect. Make sure it is an integer, and try again later.\n");
 
 					return true;
@@ -735,7 +737,7 @@ bool commands::Commands51To60(const std::string sCommand, char* cCommandArgs, co
 				else {
 					nNumOfDPOutput = std::stoi(sStringDataCommandArgs[i]);
 					if (nNumOfDPOutput < 1 || nNumOfDPOutput > 1000000) {
-						VerbosityDisplay("In CommandsFile51To60() - ERROR: Number argument is less than 1 or more than 1000000, which exceeds the allowed range for the PiOutput command.\n");
+						VerbosityDisplay("In commands::Commands51To60() - ERROR: Number argument is less than 1 or more than 1000000, which exceeds the allowed range for the PiOutput command.\n");
 						UserErrorDisplay("ERROR - Your number argument seems to be out of range of acceptable arguments of decimal places. Please ensure that the argument is not less than 1 or more than 1 million, and try again.\nSee \"pioutput -h\" for more info.\n");
 
 						return true;
@@ -858,7 +860,8 @@ bool commands::Commands51To60(const std::string sCommand, char* cCommandArgs, co
 		std::cout << wordWrap("\n\n1) I can't see the terminal text. How can I zoom in?\n  1a) You can zoom in, of course. Press and hold the Ctrl button and scroll with the mouse to your desired text size.\n"
 			"\n\n2) The error messages shown aren't detailed enough. How do I get better-quality error messages?\n  2a) To get better quality error messages, just enable the Verbosity Messages setting in the Settings command.\n"
 			"\n\n3) I'm using the Windows 7 terminal. How do I scroll up and down in the terminal without using the mouse?\n  3a) To scroll up and down without the mouse, press Alt + Space and then the keys 'E' and 'L', and then scroll with the up/down arrow keys. Use the PageUp/PageDown keys to scroll full pages in the terminal.\n"
-			"\n\n4) What is the difference between the 'old' and 'new' OptionSelect Session styles?\n  4a) The 'old' style is an inspiration from the TerminalAppGen2, the previous iteration of this program. It is very robust, simple and works by associating a number with each option, which you type in and press ENTER to select.\nThe 'new' style isn't exactly new, and has been in ZeeTerminal since v0.1.0. However, it is newer than the 'old' style, hence it's referred to as 'new'. It relies on using the arrow/WS keys to move a highlight up and down, to select an option.\n\n");
+			"\n\n4) What is the difference between the 'old' and 'new' OptionSelect Session styles?\n  4a) The 'old' style is an inspiration from the TerminalAppGen2, the previous iteration of this program. It is very robust, simple and works by associating a number with each option, which you type in and press ENTER to select.\nThe 'new' style isn't exactly new, and has been in ZeeTerminal since v0.1.0. However, it is newer than the 'old' style, hence it's referred to as 'new'. It relies on using the arrow/WS keys to move a highlight up and down, to select an option.\n"
+			"\n\n5) I want to log the output of a command straight to a file, without outputting anything to the display. How can I do that?\n  5a) To do this, you can use the ToFile feature. Use the --tofile <file> argument on the command that you want to send to a file, and it will work. Insert the file-path within <file> in this case. If you're running in ANSI mode, all escape sequences (except colour sequences) will be outputted along with the text, to the file. The <file> argument is always read from the last data string argument in the command string. Example: echo HelloWorld --tofile \"Test File.txt\"\n\n");
 
 		return true;
 	}

--- a/CommandFiles/CommandsFiles/CommandsFile_61to70.cpp
+++ b/CommandFiles/CommandsFiles/CommandsFile_61to70.cpp
@@ -262,7 +262,7 @@ bool commands::Commands61To70(const std::string sCommand, char* cCommandArgs, co
 			converter::KilometresToLightYears(dConverterArgument, bFromArgument);
 			break;
 		default:
-			VerbosityDisplay("In Commands() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
+			VerbosityDisplay("In commands::Commands61To70() - ERROR: Unknown return value from OptionSelectEngine::OptionSelect().\n");
 			UserErrorDisplay("ERROR - Unknown error occured. Please try again later.\n");
 		}
 
@@ -294,14 +294,14 @@ bool commands::Commands61To70(const std::string sCommand, char* cCommandArgs, co
 						nMinNumber = std::stold(sStringDataCommandArgs[1]);
 					}
 					else {
-						VerbosityDisplay("In Commands61To70() - ERROR: Could not detect numerical value in string-based number argument, due to isNumberld fail.\n");
+						VerbosityDisplay("In commands::Commands61To70() - ERROR: Could not detect numerical value in string-based number argument, due to isNumberld fail.\n");
 						UserErrorDisplay("ERROR - Your minimum number generation boundary argument is invalid. Please try again.\nSee \"randnum -h\" for more info.\n");
 
 						return true;
 					}
 				}
 				else {
-					VerbosityDisplay("In Commands61To70(): ERROR - Failed to detect second mandatory minimum boundary argument for random number generation. Arguments should be re-checked.\n");
+					VerbosityDisplay("In commands::Commands61To70(): ERROR - Failed to detect second mandatory minimum boundary argument for random number generation. Arguments should be re-checked.\n");
 					UserErrorDisplay("ERROR - There was no minimum boundary argument found to generate the random number. This must be included with a maximum boundary. Please add one and try again.\nSee \"randnum -h\" for more info.\n");
 
 					return true;
@@ -312,7 +312,7 @@ bool commands::Commands61To70(const std::string sCommand, char* cCommandArgs, co
 					nMaxNumber = std::stold(sStringDataCommandArgs[0]);
 				}
 				else {
-					VerbosityDisplay("In Commands61To70() - ERROR: Could not detect numerical value in string-based number argument, due to isNumberld fail.\n");
+					VerbosityDisplay("In commands::Commands61To70() - ERROR: Could not detect numerical value in string-based number argument, due to isNumberld fail.\n");
 					UserErrorDisplay("ERROR - Your maximum number generation boundary argument is invalid. Please try again.\nSee \"randnum -h\" for more info.\n");
 
 					return true;

--- a/CommandFiles/Settings.cpp
+++ b/CommandFiles/Settings.cpp
@@ -36,7 +36,7 @@ void HighlightColourSettings(short int nResult = 0, int nChoice = 0) {
 			"Modify Background Colour"
 		};
 		oseHighlight.sOptions = sOptions;
-		std::cout << std::endl;
+		std::cout << "\n";
 
 		nResult = oseHighlight.OptionSelect("Please select what you want to do for Highlight Colour:", " ___HIGHLIGHT COLOUR SETTINGS___ ");
 	}
@@ -54,14 +54,16 @@ void HighlightColourSettings(short int nResult = 0, int nChoice = 0) {
 				Exiting();
 				return;
 			}
-			std::cout << std::endl;
+			std::cout << "\n";
 		}
 		
-		ColourForegroundSwitch(&nChoice, &ConfigObjMain.sColourHighlightBack, &ConfigObjMain.sColourHighlight);
+		// Set foreground colour
+		if (ColourForegroundSwitch(&nChoice, &ConfigObjMain.sColourHighlightBack, &ConfigObjMain.sColourHighlight)) {
+			colour(LGRN, ConfigObjMain.sColourGlobalBack);
+			std::cout << CentreText("Highlight foreground colour successfully set!") << std::endl;
+			colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
+		}
 
-		colour(LGRN, ConfigObjMain.sColourGlobalBack);
-		std::cout << CentreText("Highlight foreground colour successfully set!") << std::endl;
-		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 		return;
 	}
 	else if (nResult == 2) {
@@ -76,14 +78,16 @@ void HighlightColourSettings(short int nResult = 0, int nChoice = 0) {
 				Exiting();
 				return;
 			}
-			std::cout << std::endl;
+			std::cout << "\n";
 		}
 
-		ColourBackgroundSwitch(&nChoice, &ConfigObjMain.sColourHighlightBack, &ConfigObjMain.sColourHighlight);
+		// Set background colour
+		if (ColourBackgroundSwitch(&nChoice, &ConfigObjMain.sColourHighlightBack, &ConfigObjMain.sColourHighlight)) {
+			colour(LGRN, ConfigObjMain.sColourGlobalBack);
+			std::cout << CentreText("Highlight background colour successfully set!") << std::endl;
+			colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
+		}
 
-		colour(LGRN, ConfigObjMain.sColourGlobalBack);
-		std::cout << CentreText("Highlight background colour successfully set!") << std::endl;
-		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 		return;
 	}
 	else if (nResult == -1) {
@@ -111,7 +115,7 @@ void TitleColourSettings(short int nResult = 0, int nChoice = 0) {
 			"Modify Background Colour"
 		};
 		oseTitle.sOptions = sOptions;
-		std::cout << std::endl;
+		std::cout << "\n";
 
 		nResult = oseTitle.OptionSelect("Please select what you want to do for Title Colour:", " ___TITLE COLOUR SETTINGS___ ");
 	}
@@ -129,14 +133,16 @@ void TitleColourSettings(short int nResult = 0, int nChoice = 0) {
 				Exiting();
 				return;
 			}
-			std::cout << std::endl;
+			std::cout << "\n";
 		}
 
-		ColourForegroundSwitch(&nChoice, &ConfigObjMain.sColourTitleBack, &ConfigObjMain.sColourTitle);
+		// Set foreground colour
+		if (ColourForegroundSwitch(&nChoice, &ConfigObjMain.sColourTitleBack, &ConfigObjMain.sColourTitle)) {
+			colour(LGRN, ConfigObjMain.sColourGlobalBack);
+			std::cout << CentreText("Title foreground colour successfully set!") << std::endl;
+			colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
+		}
 
-		colour(LGRN, ConfigObjMain.sColourGlobalBack);
-		std::cout << CentreText("Title foreground colour successfully set!") << std::endl;
-		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 		return;
 	}
 	else if (nResult == 2) {
@@ -151,14 +157,16 @@ void TitleColourSettings(short int nResult = 0, int nChoice = 0) {
 				Exiting();
 				return;
 			}
-			std::cout << std::endl;
+			std::cout << "\n";
 		}
 
-		ColourBackgroundSwitch(&nChoice, &ConfigObjMain.sColourTitleBack, &ConfigObjMain.sColourTitle);
+		// Set background colour
+		if (ColourBackgroundSwitch(&nChoice, &ConfigObjMain.sColourTitleBack, &ConfigObjMain.sColourTitle)) {
+			colour(LGRN, ConfigObjMain.sColourGlobalBack);
+			std::cout << CentreText("Title background colour successfully set!") << std::endl;
+			colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
+		}
 
-		colour(LGRN, ConfigObjMain.sColourGlobalBack);
-		std::cout << CentreText("Title background colour successfully set!") << std::endl;
-		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 		return;
 	}
 	else if (nResult == -1) {
@@ -204,14 +212,16 @@ void SubheadingColourSettings(short int nResult = 0, int nChoice = 0) {
 				Exiting();
 				return;
 			}
-			std::cout << std::endl;
+			std::cout << "\n";
 		}
 
-		ColourForegroundSwitch(&nChoice, &ConfigObjMain.sColourSubheadingBack, &ConfigObjMain.sColourSubheading);
+		// Set foreground colour
+		if (ColourForegroundSwitch(&nChoice, &ConfigObjMain.sColourSubheadingBack, &ConfigObjMain.sColourSubheading)) {
+			colour(LGRN, ConfigObjMain.sColourGlobalBack);
+			std::cout << CentreText("Subheading foreground colour successfully set!") << std::endl;
+			colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
+		}
 
-		colour(LGRN, ConfigObjMain.sColourGlobalBack);
-		std::cout << CentreText("Subheading foreground colour successfully set!") << std::endl;
-		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 		return;
 	}
 	else if (nResult == 2) {
@@ -226,14 +236,16 @@ void SubheadingColourSettings(short int nResult = 0, int nChoice = 0) {
 				Exiting();
 				return;
 			}
-			std::cout << std::endl;
+			std::cout << "\n";
 		}
 
-		ColourBackgroundSwitch(&nChoice, &ConfigObjMain.sColourSubheadingBack, &ConfigObjMain.sColourSubheading);
+		// Set background colour
+		if (ColourBackgroundSwitch(&nChoice, &ConfigObjMain.sColourSubheadingBack, &ConfigObjMain.sColourSubheading)) {
+			colour(LGRN, ConfigObjMain.sColourGlobalBack);
+			std::cout << CentreText("Subheading background colour successfully set!") << std::endl;
+			colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
+		}
 
-		colour(LGRN, ConfigObjMain.sColourGlobalBack);
-		std::cout << CentreText("Subheading background colour successfully set!") << std::endl;
-		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 		return;
 	}
 	else if (nResult == -1) {
@@ -374,7 +386,7 @@ void AnsiSettings(short int nChoice = 0) {
 		oseAnsi.sOptions = sOptions;
 		std::cout << std::endl;
 
-		nChoice = oseAnsi.OptionSelect("Please select your desired option for the ANSI setting:\n(Currently set to: " + BoolToString(ConfigObjMain.bAnsiVTSequences) + ")", " ___ANSI SETTINGS___ ");
+		nChoice = oseAnsi.OptionSelect("Please select your desired option for the ANSI setting:\n(Currently set to: " + BoolToString(bAnsiVTSequences) + ")", " ___ANSI SETTINGS___ ");
 	}
 	
 
@@ -533,6 +545,17 @@ void CursorSettings(short int nChoice = 0, short int nChoiceBlink = 0, short int
 				else break;
 			}
 			else break;
+		}
+	}
+
+	if (nChoice == 1 || nChoice == 3) {
+		// Doesn't work without ANSI
+		if (!bAnsiVTSequences) {
+			colour(RED, ConfigObjMain.sColourGlobalBack);
+			std::cout << wordWrap("Sorry, but this setting cannot be modified without terminal ANSI VT support.") << '\n';
+			Exiting();
+			colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
+			return;
 		}
 	}
 
@@ -1166,12 +1189,13 @@ void CarDodgeGameSettings(short int nChoiceMain = 0, int nChoiceCarTurnSpeed = 0
 			return;
 		}
 		
-		ColourForegroundSwitch(&nChoiceForeground, &ConfigObjMain.sCarDodgeGameplayColourBack, &ConfigObjMain.sCarDodgeGameplayColourFore);
-		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
+		// Set foreground colour
+		if (ColourForegroundSwitch(&nChoiceForeground, &ConfigObjMain.sCarDodgeGameplayColourBack, &ConfigObjMain.sCarDodgeGameplayColourFore)) {
+			colour(LGRN, ConfigObjMain.sColourGlobalBack);
+			std::cout << CentreText("CarDodge game foreground colour successfully set!") << std::endl;
+			colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
+		}
 
-		colour(LGRN, ConfigObjMain.sColourGlobalBack);
-		std::cout << CentreText("CarDodge game foreground colour successfully set!") << std::endl;
-		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 		return;
 	}
 	else if (nChoiceMain == 4) {
@@ -1189,12 +1213,13 @@ void CarDodgeGameSettings(short int nChoiceMain = 0, int nChoiceCarTurnSpeed = 0
 			return;
 		}
 
-		ColourBackgroundSwitch(&nChoiceBackground, &ConfigObjMain.sCarDodgeGameplayColourBack, &ConfigObjMain.sCarDodgeGameplayColourFore);
-		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
+		// Set background colour
+		if (ColourBackgroundSwitch(&nChoiceBackground, &ConfigObjMain.sCarDodgeGameplayColourBack, &ConfigObjMain.sCarDodgeGameplayColourFore)) {
+			colour(LGRN, ConfigObjMain.sColourGlobalBack);
+			std::cout << CentreText("CarDodge game background colour successfully set!") << std::endl;
+			colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
+		}
 
-		colour(LGRN, ConfigObjMain.sColourGlobalBack);
-		std::cout << CentreText("CarDodge game background colour successfully set!") << std::endl;
-		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 		return;
 	}
 	else if (nChoiceMain == -1) {
@@ -1239,12 +1264,13 @@ void GuessTheNumberGameSettings(short int nChoiceMain = 0, int nChoiceGameForegr
 			return;
 		}
 
-		ColourForegroundSwitch(&nChoiceGameForeground, &ConfigObjMain.sGTNGameplayColourBack, &ConfigObjMain.sGTNGameplayColourFore);
-		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
+		// Set foreground colour
+		if (ColourForegroundSwitch(&nChoiceGameForeground, &ConfigObjMain.sGTNGameplayColourBack, &ConfigObjMain.sGTNGameplayColourFore)) {
+			colour(LGRN, ConfigObjMain.sColourGlobalBack);
+			std::cout << CentreText("Guess The Number game foreground colour successfully set!") << std::endl;
+			colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
+		}
 
-		colour(LGRN, ConfigObjMain.sColourGlobalBack);
-		std::cout << CentreText("Guess The Number game foreground colour successfully set!") << std::endl;
-		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 		return;
 	}
 	else if (nChoiceMain == 2) {
@@ -1262,12 +1288,13 @@ void GuessTheNumberGameSettings(short int nChoiceMain = 0, int nChoiceGameForegr
 			return;
 		}
 
-		ColourBackgroundSwitch(&nChoiceGameBackground, &ConfigObjMain.sGTNGameplayColourBack, &ConfigObjMain.sGTNGameplayColourFore);
-		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
+		// Set background colour
+		if (ColourBackgroundSwitch(&nChoiceGameBackground, &ConfigObjMain.sGTNGameplayColourBack, &ConfigObjMain.sGTNGameplayColourFore)) {
+			colour(LGRN, ConfigObjMain.sColourGlobalBack);
+			std::cout << CentreText("Guess The Number game background colour successfully set!") << std::endl;
+			colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
+		}
 
-		colour(LGRN, ConfigObjMain.sColourGlobalBack);
-		std::cout << CentreText("Guess The Number game background colour successfully set!") << std::endl;
-		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 		return;
 	}
 	else if (nChoiceMain == -1) {
@@ -1293,7 +1320,7 @@ void GuessTheNumberExtremeGameSettings(short int nChoiceMain = 0, int nChoiceGam
 			"Game Background Colour"
 		};
 		oseGTNSettings.sOptions = sOptions;
-		nChoiceMain = oseGTNSettings.OptionSelect("Please select which setting you want to change relating to the Guess The Number Extreme game:", " ___GUESS THE NUMBER GAME SETTINGS___ ");
+		nChoiceMain = oseGTNSettings.OptionSelect("Please select which setting you want to change relating to the Guess The Number Extreme game:", " ___GUESS THE NUMBER EXTREME GAME SETTINGS___ ");
 	}
 
 
@@ -1312,12 +1339,13 @@ void GuessTheNumberExtremeGameSettings(short int nChoiceMain = 0, int nChoiceGam
 			return;
 		}
 
-		ColourForegroundSwitch(&nChoiceGameForeground, &ConfigObjMain.sGTNEGameplayColourBack, &ConfigObjMain.sGTNEGameplayColourFore);
-		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
+		// Set foreground colour
+		if (ColourForegroundSwitch(&nChoiceGameForeground, &ConfigObjMain.sGTNEGameplayColourBack, &ConfigObjMain.sGTNEGameplayColourFore)) {
+			colour(LGRN, ConfigObjMain.sColourGlobalBack);
+			std::cout << CentreText("Guess The Number Extreme game foreground colour successfully set!") << std::endl;
+			colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
+		}
 
-		colour(LGRN, ConfigObjMain.sColourGlobalBack);
-		std::cout << CentreText("Guess The Number Extreme game foreground colour successfully set!") << std::endl;
-		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 		return;
 	}
 	else if (nChoiceMain == 2) {
@@ -1335,12 +1363,13 @@ void GuessTheNumberExtremeGameSettings(short int nChoiceMain = 0, int nChoiceGam
 			return;
 		}
 
-		ColourBackgroundSwitch(&nChoiceGameBackground, &ConfigObjMain.sGTNEGameplayColourBack, &ConfigObjMain.sGTNEGameplayColourFore);
-		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
+		// Set background colour
+		if (ColourBackgroundSwitch(&nChoiceGameBackground, &ConfigObjMain.sGTNEGameplayColourBack, &ConfigObjMain.sGTNEGameplayColourFore)) {
+			colour(LGRN, ConfigObjMain.sColourGlobalBack);
+			std::cout << CentreText("Guess The Number Extreme game background colour successfully set!") << std::endl;
+			colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
+		}
 
-		colour(LGRN, ConfigObjMain.sColourGlobalBack);
-		std::cout << CentreText("Guess The Number Extreme game background colour successfully set!") << std::endl;
-		colour(ConfigObjMain.sColourGlobal, ConfigObjMain.sColourGlobalBack);
 		return;
 	}
 	else if (nChoiceMain == -1) {

--- a/Core/ZTConstDefinitions.h
+++ b/Core/ZTConstDefinitions.h
@@ -1,10 +1,10 @@
 #pragma once
 
 // ZeeTerminal Source Code Version
-constexpr const char* ZT_VERSION = "0.9.0";
+constexpr const char* ZT_VERSION = "1.0.0";
 
 // Array size for all argument arrays
-constexpr int nArgArraySize = 128;
+constexpr int nArgArraySize = 256;
 
 // Text formatting definitions
 #define ULINE 4

--- a/Core/ZeeTerminalCore.cpp
+++ b/Core/ZeeTerminalCore.cpp
@@ -132,6 +132,12 @@ namespace zt {
 				else if (sColourBackgroundChoice == LGRN && sColourForegroundChoice == LWHT) {
 					sColourForegroundChoice = BLK;
 				}
+				else if (sColourBackgroundChoice == LCYN && sColourForegroundChoice == LGRN) {
+					sColourForegroundChoice = BLK;
+				}
+				else if (sColourBackgroundChoice == LGRN && sColourForegroundChoice == LCYN) {
+					sColourForegroundChoice = BLK;
+				}
 			}
 
 			// Foreground
@@ -1103,24 +1109,13 @@ namespace zt {
 	// SetWindowTitle - Function to set title for the console window.
 	// Parameters: sTitle for the title string.
 	bool SetWindowTitle(std::string sTitle) {
-		if (bAnsiVTSequences) {
-			if (sTitle.length() > 254) {
-				VerbosityDisplay("ERROR: In SetWindowTitle() - String argument incorrect due to ANSI 254 max string char limit for title.\n");
-				return false;
-			}
-
-			// Use ANSI VT sequences if they work on current terminal
-			std::cout << "\x1b]0;" << sTitle << "\x1b\x5c";
+		// Use Windows SetConsoleTitleA if ANSI VT sequences don't work on current terminal window
+		if (SetConsoleTitleA(sTitle.c_str())) {
+			return true;
 		}
 		else {
-			// Use Windows SetConsoleTitleA if ANSI VT sequences don't work on current terminal window
-			if (SetConsoleTitleA(sTitle.c_str())) {
-				return true;
-			}
-			else {
-				VerbosityDisplay("ERROR: In SetWindowTitle() - String argument incorrect due to WIN32 API 254 max string char limit for title.\n");
-				return false;
-			}
+			VerbosityDisplay("ERROR: In SetWindowTitle() - String argument incorrect due to WIN32 API 65535 max string character limit for title.\n");
+			return false;
 		}
 
 		return true;

--- a/Engine/FileParse-System/FileParse-System.cpp
+++ b/Engine/FileParse-System/FileParse-System.cpp
@@ -43,7 +43,7 @@ namespace fparse {
 
 		// 2. Check file stream
 		if (LineParseTest.fail()) {
-			VerbosityDisplay("In InitialiseFileParse(): ERROR - Failed to initialise FileParse System due to bad file path (sFilePath is nonexistent).\n");
+			VerbosityDisplay("In InitialiseFileParse(): ERROR - Failed to initialise FileParse System due to bad file path, lack of permissions or out of memory.\n");
 			LineParseTest.close();
 			UninitialiseFileParse();
 			return false;

--- a/GameFiles/CarDodge/CarDodge_CodeFiles/CarDodgeMain/CarDodgeMain.cpp
+++ b/GameFiles/CarDodge/CarDodge_CodeFiles/CarDodgeMain/CarDodgeMain.cpp
@@ -58,7 +58,7 @@ void CarDodgeMain::UpdatePanelInfo() {
 	SetCursorPosition(nScreenWidth - nRightBorderWidth + 3, 9);
 	std::cout << "Level: " << (nSessionLevel == 12 ? "OMEGA" : std::to_string(nSessionLevel));
 	SetCursorPosition(nScreenWidth - nRightBorderWidth + 3, 10);
-	std::cout << "Interval Period: " << nSessionEnemyCarInterval.count() * (nSessionPowerUp == 1 ? 2 : 1) << "ms ";
+	std::cout << "Interval Period: " << nSessionEnemyCarInterval.count() * (nSessionPowerUp == 1 ? 2 : 1) << (nSessionEnemyCarInterval.count() * (nSessionPowerUp == 1 ? 2 : 1) < 100 ? "ms " : "ms"); // Display milliseconds with a space when less than 100ms (3 digits) interval period to prevent overflow to next line
 	SetCursorPosition(nScreenWidth - nRightBorderWidth + 3, 11);
 	std::cout << "_______________";
 

--- a/GameFiles/GuessTheNumber/GuessTheNumber.cpp
+++ b/GameFiles/GuessTheNumber/GuessTheNumber.cpp
@@ -12,7 +12,7 @@ void GuessTheNumber::MainGameFn() {
 	while (true) 
 	{
 		// Set up environment
-		int nCorrectRandNum = RandNumld(100, 0);
+		int nCorrectRandNum = RandNumld(100, 1);
 		int nNumberOfTriesUsed = 0;
 		cls();
 		std::cout << wordWrap("\nLet the games begin!\n");
@@ -35,8 +35,7 @@ void GuessTheNumber::MainGameFn() {
 			}
 
 			// Input guess number prompt
-			int nUserGuessNumber = 0;
-			nUserGuessNumber = NumInputi("\nInput a guess number between 1 and 100 (0 to exit game): > ");
+			int nUserGuessNumber = NumInputi("\nInput a guess number between 1 and 100 (0 to exit game): > ");
 
 			// Exit to menu on 0
 			if (nUserGuessNumber == 0) {
@@ -62,9 +61,9 @@ void GuessTheNumber::MainGameFn() {
 				std::cout << wordWrap("That guess number was higher than 100. Please try again.\n");
 				continue;
 			}
-			// if guess number is less than 0
-			else if (nUserGuessNumber < 0) {
-				std::cout << wordWrap("That guess number was less than 0. Please try again.\n");
+			// if guess number is less than 1
+			else if (nUserGuessNumber < 1) {
+				std::cout << wordWrap("That guess number was less than 1. Please try again.\n");
 				continue;
 			}
 
@@ -175,7 +174,7 @@ void GuessTheNumber::GuessTheNumber_MainMenu()
 			cls();
 			std::cout << "################################# GUESS THE NUMBER ##############################################\n\n";
 
-			slowcharfn(true, "You have " + std::to_string(nNumOfTriesAllowed) + " tries to guess a number between 0 and 100 inclusive. \n");
+			slowcharfn(true, "You have " + std::to_string(nNumOfTriesAllowed) + " tries to guess a number between 1 and 100 inclusive. \n");
 			slowcharfn(true, "If you get the answer wrong, the game will tell you if your answer was higher or lower than the correct number.");
 			std::cout << "\n";
 			slowcharfn(true, "Good luck!\n");

--- a/ZeeTerminal.cpp
+++ b/ZeeTerminal.cpp
@@ -268,7 +268,7 @@ int main(int argc, char* argv[])
 		std::istringstream sCommandInputIn(sCommandInput);
 
 		// For loop to start checking from after any spaces inputted by the user
-		for (int i = 0; i < sCommandInput.length() && !sCommandInputIn.eof(); i++) {
+		for (size_t i = 0; i < sCommandInput.length() && !sCommandInputIn.eof(); i++) {
 			std::getline(sCommandInputIn, sCommand, ' ');
 			if (sCommand != "") break;
 		}
@@ -301,7 +301,7 @@ int main(int argc, char* argv[])
 		sCommandInputRAW = sCommand;
 
 		// Make all letters inside sCommand lowercase
-		for (int i = 0; i < sCommand.length(); i++) {
+		for (size_t i = 0; i < sCommand.length(); i++) {
 			sCommand[i] = std::tolower(sCommand[i]);
 		}
 
@@ -442,13 +442,17 @@ int main(int argc, char* argv[])
 		for (size_t nFirstMarkerPos = 0, nLastMarkerPos = 0, i = 0, nViableSpacePos = 0; i < nArgArraySize; i++, nFirstMarkerPos = 0, nLastMarkerPos = 0, nViableSpacePos = 0)
 		{
 			// Check for next viable space location
+			bool bExitLoopEarly = false; // optimisation for exiting loop early
 			while (true) 
 			{
 				// a. Find next raw space location
 				nViableSpacePos = sCommandArgsBuffer.find(" ", nViableSpacePos);
 
 				// b. Check if raw space location is at end of string
-				if (nViableSpacePos == std::string::npos || nViableSpacePos == sCommandArgsBuffer.find_last_of(" ", sCommandArgsBuffer.length())) break;
+				if (nViableSpacePos == std::string::npos || nViableSpacePos == sCommandArgsBuffer.find_last_of(" ", std::string::npos)) {
+					bExitLoopEarly = true;
+					break;
+				}
 
 				// c. Increment nViableSpacePos to not just run in loops when checking space location
 				nViableSpacePos++;
@@ -459,6 +463,9 @@ int main(int argc, char* argv[])
 					break;
 				}
 			}
+
+			// Exit the for loop if there is nothing left to find
+			if ((sCommandArgsBuffer.find(" ", nViableSpacePos) == std::string::npos || bExitLoopEarly) && sCommandArgsBuffer.find("\"", 0) == std::string::npos) break;
 
 			// Check what string argument type is first, and then check that first so everything in the array is in order
 			if (sCommandArgsBuffer.find(" ", nViableSpacePos) < sCommandArgsBuffer.find("\"", 0)) 


### PR DESCRIPTION
- This update is mainly a bugfix update, as this is the first non-beta release of ZeeTerminal.

__New Features__
- The argument array size for any argument array has increased to 256 from 128, which allows a maximum of 768 arguments in one command (256 string-option, 256 string-data, 256 character).

__Changes and Bugfixes__
- Fixed issues in different commands where verbose messages from those commands would not indicate as coming from within their actual function, but within a singular, older Commands() function. This has been fixed to say Commands1To10() and etcetera.
- Fixed an issue when the Title command is used with the ToFile feature in ANSI mode, where it doesn't set the title to the window.
- Increased the character limit of the size of the title in the Title command to 65535 characters, up from 254.
- In the About command, "beta build" has been changed to "public stable release build", as this is the first public release build of this program.
- Improved reliability of the command input system by using size_t when comparing with strings or performing string operations, instead of using int.
- Optimised the string data argument parser for instances of command execution with few data arguments.
- In the Colour Tester, ColourNumbers, MMSYSTEM API Sound Test, High-Res Nanosecond Stopwatch, Beep Sound Test and TableEngine Tester in the DevTools command, you can now exit them with the ESC key (The TableEngine Tester can only be exited like this after the table has been generated).
- Fixed an issue where the 3rd option in the DevTools command (ColourNumbers) would not execute properly.
- Fixed a grammar mistake in the TableEngine Tester in the DevTools command (said "now many columns" instead of "how many columns")
- Fixed issues where using the old OptionSelect style causes duplicated option numbers in the Colour command (for foreground and background colour adjustment).
- Fixed issue where there are 3 newline characters instead of 2 in the MediaPlayer help pages, after the Example line.
- Changed some code in the Date command to output the date strictly in the DD/MM/YYYY and HH:MM:SS format.
- Fixed an issue where in the MediaPlayer command, fast-forwarding all the way to the end of the media file would cause it to exit immediately, which could be unintended.
- Fixed an issue with the AudioPlayer and MediaPlayer commands where when repeat is activated and the audio or media track has been repeated, exiting afterwards would disable the cursor.
- Fixed an issue in the TTS help pages where the Note line has improper word wrapping.
- Fixed a grammar error in the AudioPlayer command and its help page, where the audio formats list did not end in a full stop.
- Fixed an issue in the Timer command and its help page, where whenever it says "Press any key to exit the timer", it should say "Press ESC to exit the timer".
- Fixed an issue in Guess The Number Extreme Game Settings, where the title does not include the word 'extreme'.
- Fixed an issue in the Copy help pages where there is a missing > character in the Syntax line.
- Changed the centred subheading text in the CopyFile help pages to say "This command copies the contents of a file to another file." This more accurately reflects what the CopyFile command is supposed to do.
- Fixed an issue where the ShellExecute command would not execute a CMD command if running from user input (NOT arguments).
- Improved error message for "no file exists" in "Hacker --typecustom" and the FileParse system to include that permissions and memory may not be available.
- Changed the examples in the Shutdown and Reboot help pages to use "-t 10" instead of "-t 5" so that if the user is trying the example, they have more time to execute "shutdown -c" or "restart -c".
- Added default text to -m argument in the Memtest help page.
- Fixed an issue in the Hibernate command help page, where "What this command does:" is displayed instead of "Possible arguments for this command:" above the arguments list.
- Added low-contrast detection for Light Aqua and Light Green.
- In the PiOutput command, the last line under the "What this command does" subheading has been modified to say "of ZeeTerminal" instead of "of this program".
- Fixed issues in the Guess The Number game, where the boundary in the "How To Play" section of the game describes guessing a number between 0 and 100 when it is meant to be between 1 and 100. Other bugs in the code relating to these boundaries have also been fixed.
- Added FAQ question in the FAQ command about the ToFile feature that was unveiled in update v0.9.0.
- Improved clarity of the prompts outputted by the FileCryptor command when encrypting data with the RyRyCryptor encryption algorithm.
- Fixed an issue where when the key value 0 is used to encrypt data, the command re-prompts for a key in the FileCryptor command, when used with the RyRyCryptor encryption algorithm.
- Added centred subheading text (the text just under the title) in these command help pages: ConfigAction, Rickroll, Beepsounds, Hacker, Logoff, Shutdown, Reboot, Hibernate, ResetExpl, MemTest, RandCol, CLS, Pause, CommandNum, Slowchar, ReverseText, Disp, SysInfo, Help, Tutorial, DevTools, Colour, Settings and Date.
- Fixed issues in the Colour and Settings commands where even if an error occurs when setting specific colours to anything, it would say that it was successful.
- Added centred titles to the Echo and Tutorial commands.
- Fixed an issue in the CarDodge game (accessible through the Game command) where any interval period more than 100ms causes the output on the info pane to overflow further than what is allowed, causing inconsistent output.
- Added notice in the ANSI VT Testing Environment and the Colour Tester in the DevTools command that some older terminals, e.g Windows 7 terminals, cannot interpret ANSI escape codes properly.
- Added colour to hertz value output in the Beep Sound Test in the DevTools command.
- Fixed an issue where when running on a non ANSI-supporting system, trying to change the cursor blinking or cursor shape from an argument will say that it worked, but it really didn't change anything. This has been fixed to show an error message instead.
- Fixed an issue where on a non ANSI-supporting system, the current ANSI setting may be incorrectly presented as being enabled when it's disabled.